### PR TITLE
Tweak API key handling

### DIFF
--- a/ckanapi.py
+++ b/ckanapi.py
@@ -88,8 +88,9 @@ class ActionShortcut(object):
         self._ckan = ckan
 
     def __getattr__(self, name):
-        def action(**kwargs):
-            return self._ckan.call_action(name, kwargs)
+        def action(apikey=None, **kwargs):
+            return self._ckan.call_action(name, data_dict=kwargs,
+                                          apikey=apikey)
         return action
 
 
@@ -138,8 +139,8 @@ class RemoteCKAN(object):
 
     :param address: the web address of the CKAN instance, e.g.
                     'http://demo.ckan.org', stored as self.address
-    :param api_key: the API key to pass as an 'X-CKAN-API-Key' header
-                    when actions are called, stored as self.api_key
+    :param apikey: the API key to pass as an 'X-CKAN-API-Key' header
+                    when actions are called, stored as self.apikey
     :param request_fn: a callable that will be used to make requests
 
     The default implementation of request_fn is::
@@ -153,14 +154,14 @@ class RemoteCKAN(object):
               return e.code, e.read()
 
     """
-    def __init__(self, address, api_key=None, request_fn=None):
+    def __init__(self, address, apikey=None, request_fn=None):
         self.address = address
-        self.api_key = api_key
+        self.apikey = apikey
         self.action = ActionShortcut(self)
         if request_fn:
             self._request_fn = request_fn
 
-    def call_action(self, action, data_dict=None):
+    def call_action(self, action, data_dict=None, apikey=None):
         """
         :param action: the action name, e.g. 'package_create'
         :param data_dict: the dict to pass to the action as JSON,
@@ -171,7 +172,8 @@ class RemoteCKAN(object):
         function will convert it back to an exception that matches the
         one the action function itself raised.
         """
-        url, data, headers = prepare_action(action, data_dict, self.api_key)
+        url, data, headers = prepare_action(action, data_dict,
+                                            apikey or self.apikey)
         status, response = self._request_fn(self.address + url, data, headers)
         return reverse_apicontroller_action(status, response)
 
@@ -190,15 +192,15 @@ class TestAppCKAN(object):
 
     :param test_app: the paste.fixture.TestApp instance, stored as
                     self.test_app
-    :param api_key: the API key to pass as an 'X-CKAN-API-Key' header
-                    when actions are called, stored as self.api_key
+    :param apikey: the API key to pass as an 'X-CKAN-API-Key' header
+                    when actions are called, stored as self.apikey
     """
-    def __init__(self, test_app, api_key=None):
+    def __init__(self, test_app, apikey=None):
         self.test_app = test_app
-        self.api_key = api_key
+        self.apikey = apikey
         self.action = ActionShortcut(self)
 
-    def call_action(self, action, data_dict=None):
+    def call_action(self, action, data_dict=None, apikey=None):
         """
         :param action: the action name, e.g. 'package_create'
         :param data_dict: the dict to pass to the action as JSON,
@@ -209,12 +211,13 @@ class TestAppCKAN(object):
         function will convert it back to an exception that matches the
         one the action function itself raised.
         """
-        url, data, headers = prepare_action(action, data_dict, self.api_key)
+        url, data, headers = prepare_action(action, data_dict,
+                                            apikey or self.apikey)
         r = self.test_app.post(url, data, headers, expect_errors=True)
         return reverse_apicontroller_action(r.status, r.body)
 
 
-def prepare_action(action, data_dict=None, api_key=None):
+def prepare_action(action, data_dict=None, apikey=None):
     """
     Return action_url, data_json, http_headers
     """
@@ -222,9 +225,10 @@ def prepare_action(action, data_dict=None, api_key=None):
         data_dict = {}
     data = json.dumps(data_dict)
     headers = {'Content-Type': 'application/json'}
-    if api_key:
-        headers['X-CKAN-API-Key'] = api_key
-        headers['Authorization'] = api_key
+    if apikey:
+        apikey = str(apikey)
+        headers['X-CKAN-API-Key'] = apikey
+        headers['Authorization'] = apikey
     url = '/api/action/' + action
     return url, data, headers
 


### PR DESCRIPTION
1. Call it apikey not api_key (match internal CKAN)
2. Allow passing apikey as an optional parameter when calling action
   functions. If none is passed, it falls back on the API key that was
   passed to **init** (if any).

This just means if I want to call different actions with different API
keys (common in tests) I don't need to init several API client objects.
1. Call str() on apikey before using it, this prevents crashes when e.g.
   someone passes a unicode as the api key.
