### PR TITLE
Improve error handing if using CKAN API client for a Socrata data catalog

### DIFF
--- a/ckanapi/common.py
+++ b/ckanapi/common.py
@@ -5,7 +5,8 @@ Code shared by LocalCKAN, RemoteCKAN and TestCKAN
 import json
 
 from ckanapi.errors import (CKANAPIError, NotAuthorized, NotFound,
-    ValidationError, SearchQueryError, SearchError, SearchIndexError)
+    ValidationError, SearchQueryError, SearchError, SearchIndexError,
+    ServerIncompatibleError)
 
 class ActionShortcut(object):
     """
@@ -85,8 +86,8 @@ def reverse_apicontroller_action(url, status, response):
     except (AttributeError, ValueError):
         err = {}
 
-    if not isinstance(err, dict):
-        err = {}
+    if not isinstance(err, dict):  # possibly a Socrata API.
+        raise ServerIncompatibleError(repr([url, status, response]))
 
     etype = err.get('__type')
     emessage = err.get('message', '').split(': ', 1)[-1]

--- a/ckanapi/errors.py
+++ b/ckanapi/errors.py
@@ -1,3 +1,10 @@
+class ServerIncompatibleError(Exception):
+    """
+    The error raised from RemoteCKAN.call_action when the API doesn't behave
+    like a CKAN API.
+    """
+
+
 class CKANAPIError(Exception):
     """
     The error raised from RemoteCKAN.call_action when no other error
@@ -14,6 +21,7 @@ class CKANAPIError(Exception):
 
     def __str__(self):
         return self.extra_msg
+
 
 try:
     import ckan


### PR DESCRIPTION
Socrata returns JSON where the "error" key is a boolean. The CKAN API client expects the "error" key to be a dictionary. If "error" is not a dictionary, this PR makes it an empty dictionary.

Without this PR, you get `AttributeError: 'bool' object has no attribute 'get'`, which is totally opaque.
