### PR TITLE
inline JSON action arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,39 @@ commands. When connecting to a local CKAN instance the site user
 (sysadmin) is used by default.
 
 
+### Action Arguments
+
+Simple action arguments may be passed in KEY=STRING form for string
+values or in KEY:JSON form for JSON values.
+
+E.g. to view a dataset:
+
+```
+$ ckanapi action package_show id=my-dataset-name
+{
+  "name": "my-dataset-name",
+  ...
+}
+
+```
+
+E.g. to get the number of datasets for each organization:
+
+```
+$ ckanapi action package_search 'facet.field:["organization"]' rows:0
+{
+  "facets": {
+    "organization": {
+      "org1": 42,
+      "org2": 21,
+      ...
+    }
+  },
+  ...
+}
+```
+
+
 ### Bulk operations
 
 Datasets, groups and organizations may be dumped to

--- a/ckanapi/cli/action.py
+++ b/ckanapi/cli/action.py
@@ -29,7 +29,11 @@ def action(ckan, arguments, stdin=None):
                 continue
             key, p, value = kv.partition(':')
             if p:
-                value = json.loads(value)
+                try:
+                    value = json.loads(value)
+                except ValueError:
+                    raise CLIError("KEY:JSON argument %r has invalid JSON "
+                        "value %r" % (key, value))
                 action_args[key] = value
                 continue
             raise CLIError("argument not in the form KEY=STRING or KEY:JSON "

--- a/ckanapi/cli/action.py
+++ b/ckanapi/cli/action.py
@@ -5,6 +5,7 @@ implementation of the action cli command
 import sys
 import json
 from ckanapi.cli.utils import compact_json, pretty_json
+from ckanapi.errors import CLIError
 
 
 def action(ckan, arguments, stdin=None):
@@ -31,6 +32,8 @@ def action(ckan, arguments, stdin=None):
                 value = json.loads(value)
                 action_args[key] = value
                 continue
+            raise CLIError("argument not in the form KEY=STRING or KEY:JSON "
+                "%r" % kv)
 
     result = ckan.call_action(arguments['ACTION_NAME'], action_args)
 

--- a/ckanapi/cli/action.py
+++ b/ckanapi/cli/action.py
@@ -7,10 +7,9 @@ import json
 from ckanapi.cli.utils import compact_json, pretty_json
 
 
-def action(ckan, arguments,
-        stdin=None):
+def action(ckan, arguments, stdin=None):
     """
-    call an action with KEY=VALUE args, yield the result
+    call an action with KEY=STRING, KEY:JSON or JSON args, yield the result
     """
     if stdin is None:
         stdin = getattr(sys.stdin, 'buffer', sys.stdin)
@@ -22,9 +21,17 @@ def action(ckan, arguments,
             arguments['--input']).read().decode('utf-8'))
     else:
         action_args = {}
-        for kv in arguments['KEY=VALUE']:
+        for kv in arguments['KEY=STRING']:
             key, p, value = kv.partition('=')
-            action_args[key] = value
+            if p:
+                action_args[key] = value
+                continue
+            key, p, value = kv.partition(':')
+            if p:
+                value = json.loads(value)
+                action_args[key] = value
+                continue
+
     result = ckan.call_action(arguments['ACTION_NAME'], action_args)
 
     if arguments['--output-jsonl']:

--- a/ckanapi/cli/main.py
+++ b/ckanapi/cli/main.py
@@ -2,7 +2,7 @@
 
 Usage:
   ckanapi action ACTION_NAME
-          [KEY=VALUE ... | -i | -I JSON_INPUT] [-j | -J]
+          [(KEY=STRING | KEY:JSON) ... | -i | -I JSON_INPUT] [-j | -J]
           [[-c CONFIG] [-u USER] | -r SITE_URL [-a APIKEY] [-g]]
   ckanapi load (datasets | groups | organizations | users | related)
           [-I JSONL_INPUT] [-s START] [-m MAX] [-p PROCESSES] [-l LOG_FILE]

--- a/ckanapi/cli/main.py
+++ b/ckanapi/cli/main.py
@@ -53,6 +53,7 @@ from pkg_resources import load_entry_point
 from ckanapi.version import __version__
 from ckanapi.remoteckan import RemoteCKAN
 from ckanapi.localckan import LocalCKAN
+from ckanapi.errors import CLIError
 from ckanapi.cli.load import load_things
 from ckanapi.cli.dump import dump_things
 from ckanapi.cli.action import action
@@ -84,9 +85,13 @@ def main(running_with_paster=False):
         ckan = LocalCKAN(username=arguments['--ckan-user'])
 
     if arguments['action']:
-        for r in action(ckan, arguments):
-            sys.stdout.write(r)
-        return
+        try:
+            for r in action(ckan, arguments):
+                sys.stdout.write(r)
+            return
+        except CLIError, e:
+            sys.stderr.write(e.args[0] + '\n')
+            return 1
 
     things = ['datasets', 'groups', 'organizations', 'users', 'related']
     thing = [x for x in things if arguments[x]]

--- a/ckanapi/errors.py
+++ b/ckanapi/errors.py
@@ -23,6 +23,10 @@ class CKANAPIError(Exception):
         return self.extra_msg
 
 
+class CLIError(Exception):
+    pass
+
+
 try:
     import ckan
 

--- a/ckanapi/tests/test_cli_action.py
+++ b/ckanapi/tests/test_cli_action.py
@@ -116,3 +116,14 @@ class TestCLIAction(unittest.TestCase):
             })
         self.assertRaises(CLIError, list, rval)
 
+    def test_bad_key_json(self):
+        ckan = MockCKAN('shake_it', {'who': 'me'}, "yeah")
+        rval = action(ckan, {
+            'ACTION_NAME': 'shake_it',
+            'KEY=STRING': ['who:me'],
+            '--output-json': False,
+            '--output-jsonl': False,
+            '--input-json': False,
+            '--input': None,
+            })
+        self.assertRaises(CLIError, list, rval)

--- a/ckanapi/tests/test_cli_action.py
+++ b/ckanapi/tests/test_cli_action.py
@@ -26,7 +26,7 @@ class TestCLIAction(unittest.TestCase):
         ckan = MockCKAN('shake_it', {'who': 'me'}, {"oh": ["right", "on"]})
         rval = action(ckan, {
             'ACTION_NAME': 'shake_it',
-            'KEY=VALUE': ['who=me'],
+            'KEY=STRING': ['who=me'],
             '--output-json': False,
             '--output-jsonl': False,
             '--input-json': False,
@@ -45,7 +45,7 @@ class TestCLIAction(unittest.TestCase):
         ckan = MockCKAN('shake_it', {'who': 'me'}, ["right", "on"])
         rval = action(ckan, {
             'ACTION_NAME': 'shake_it',
-            'KEY=VALUE': ['who=me'],
+            'KEY=STRING': ['who=me'],
             '--output-json': True,
             '--output-jsonl': False,
             '--input-json': False,
@@ -57,7 +57,7 @@ class TestCLIAction(unittest.TestCase):
         ckan = MockCKAN('shake_it', {'who': 'me'}, {"oh": ["right", "on"]})
         rval = action(ckan, {
             'ACTION_NAME': 'shake_it',
-            'KEY=VALUE': ['who=me'],
+            'KEY=STRING': ['who=me'],
             '--output-json': False,
             '--output-jsonl': True,
             '--input-json': False,
@@ -69,7 +69,7 @@ class TestCLIAction(unittest.TestCase):
         ckan = MockCKAN('shake_it', {'who': 'me'}, [99,98,97])
         rval = action(ckan, {
             'ACTION_NAME': 'shake_it',
-            'KEY=VALUE': ['who=me'],
+            'KEY=STRING': ['who=me'],
             '--output-json': False,
             '--output-jsonl': True,
             '--input-json': False,
@@ -81,7 +81,7 @@ class TestCLIAction(unittest.TestCase):
         ckan = MockCKAN('shake_it', {'who': ['just', 'me']}, "yeah")
         rval = action(ckan, {
                 'ACTION_NAME': 'shake_it',
-                'KEY=VALUE': ['who=me'],
+                'KEY=STRING': ['who=me'],
                 '--output-json': False,
                 '--output-jsonl': False,
                 '--input-json': True,

--- a/ckanapi/tests/test_cli_action.py
+++ b/ckanapi/tests/test_cli_action.py
@@ -91,5 +91,14 @@ class TestCLIAction(unittest.TestCase):
             )
         self.assertEqual(b''.join(rval), b'"yeah"\n')
 
-
-
+    def test_key_json(self):
+        ckan = MockCKAN('shake_it', {'who': ['just', 'me']}, "yeah")
+        rval = action(ckan, {
+                'ACTION_NAME': 'shake_it',
+                'KEY=STRING': ['who:["just", "me"]'],
+                '--output-json': False,
+                '--output-jsonl': False,
+                '--input-json': False,
+                '--input': None,
+            })
+        self.assertEqual(b''.join(rval), b'"yeah"\n')

--- a/ckanapi/tests/test_cli_action.py
+++ b/ckanapi/tests/test_cli_action.py
@@ -1,4 +1,5 @@
 from ckanapi.cli.action import action
+from ckanapi.errors import CLIError
 try:
     import unittest2 as unittest
 except ImportError:
@@ -94,11 +95,24 @@ class TestCLIAction(unittest.TestCase):
     def test_key_json(self):
         ckan = MockCKAN('shake_it', {'who': ['just', 'me']}, "yeah")
         rval = action(ckan, {
-                'ACTION_NAME': 'shake_it',
-                'KEY=STRING': ['who:["just", "me"]'],
-                '--output-json': False,
-                '--output-jsonl': False,
-                '--input-json': False,
-                '--input': None,
+            'ACTION_NAME': 'shake_it',
+            'KEY=STRING': ['who:["just", "me"]'],
+            '--output-json': False,
+            '--output-jsonl': False,
+            '--input-json': False,
+            '--input': None,
             })
         self.assertEqual(b''.join(rval), b'"yeah"\n')
+
+    def test_bad_arg(self):
+        ckan = MockCKAN('shake_it', {'who': 'me'}, "yeah")
+        rval = action(ckan, {
+            'ACTION_NAME': 'shake_it',
+            'KEY=STRING': ['who'],
+            '--output-json': False,
+            '--output-jsonl': False,
+            '--input-json': False,
+            '--input': None,
+            })
+        self.assertRaises(CLIError, list, rval)
+


### PR DESCRIPTION
Some action parameters can only be passed as JSON (like package_search facets and datastore_create parameters) and it can be a pain to use the -i option to pipe in a JSON object containing all parameters. This change lets us mix and match KEY=STRING and KEY:JSON parameters. KEY:JSON parameters parse the right side as JSON before passing to CKAN.

e.g.

```
echo '{"facet.field":["organization"], "rows":0}' | ckanapi action package_search -i
```

can now be written as

```
ckanapi action package_search 'facet.field:["organization"]' rows:0
```
