### PR TITLE
support for logo and resource migration

### DIFF
--- a/ckanapi/cli/load.py
+++ b/ckanapi/cli/load.py
@@ -292,7 +292,7 @@ def _upload_logo(ckan,obj):
     for key in obj.keys():
         if isinstance(obj[key],(dict,list)):
             obj.pop(key)                            #dict/list objects can't be encoded
-    if urlparse(obj['image_url']).scheme:                  # logo is an external link
+    if urlparse(obj['image_url']).netloc:                  # logo is an external link
         obj['clear_upload'] = True
         obj['image_upload'] = obj['image_url']
     else:

--- a/ckanapi/cli/load.py
+++ b/ckanapi/cli/load.py
@@ -8,6 +8,7 @@ import json
 import requests
 from datetime import datetime
 import re
+from urlparse import urlparse
 
 from ckanapi.errors import (NotFound, NotAuthorized, ValidationError,
     SearchIndexError)
@@ -288,7 +289,7 @@ def _upload_logo(ckan,obj):
     for key in obj.keys():
         if isinstance(obj[key],(dict,list)):
             obj.pop(key)                            #dict/list objects can't be encoded
-    if 'http' in obj['image_url']:                  # logo is an external link
+    if urlparse(obj['image_url']).scheme:                  # logo is an external link
         obj['clear_upload'] = True
         obj['image_upload'] = obj['image_url']
     else:

--- a/ckanapi/cli/load.py
+++ b/ckanapi/cli/load.py
@@ -8,7 +8,10 @@ import json
 import requests
 from datetime import datetime
 import re
-from urlparse import urlparse
+try:
+    from urllib.parse import urlparse
+except ImportError:
+    from urlparse import urlparse
 
 from ckanapi.errors import (NotFound, NotAuthorized, ValidationError,
     SearchIndexError)

--- a/ckanapi/cli/load.py
+++ b/ckanapi/cli/load.py
@@ -205,10 +205,10 @@ def load_things_worker(ckan, thing, arguments,
                     r = ckan.call_action(thing_update, obj)
                 else:
                     r = ckan.call_action(thing_create, obj)
-                users = obj['users']
                 if thing == 'datasets' and 'resources' in obj:# check if it is needed to upload resources when creating/updating packages
                         _upload_resources(ckan,obj,arguments)
                 elif thing in ['groups','organizations'] and 'image_display_url' in obj:   #load images for groups and organizations
+                    users = obj['users']
                     _upload_logo(ckan,obj)
                     obj.pop('image_upload')
                     obj['users'] = users

--- a/ckanapi/cli/main.py
+++ b/ckanapi/cli/main.py
@@ -5,8 +5,8 @@ Usage:
           [KEY=VALUE ... | -i | -I JSON_INPUT] [-j | -J]
           [[-c CONFIG] [-u USER] | -r SITE_URL [-a APIKEY] [-g]]
   ckanapi load (datasets | groups | organizations | users | related)
-          [-I JSONL_INPUT] [-s START] [-m MAX] [-p PROCESSES] [-l LOG_FILE]
-          [-n | -o] [-qwz] [[-c CONFIG] [-u USER] | -r SITE_URL [-a APIKEY]]
+          [-I JSONL_INPUT] [-s START] [-m MAX] [-p PROCESSES] [-l LOG_FILE] [-e]
+          [-n | -o] [-qwz] [[-c CONFIG] [-u USER] | -r SITE_URL [-a APIKEY]] [--resources]
   ckanapi dump (datasets | groups | organizations | users | related)
           (ID_OR_NAME ... | --all) ([-O JSONL_OUTPUT] | [-D DIRECTORY])
           [-p PROCESSES] [-qwz] [[-c CONFIG] [-u USER] | -r SITE_URL [-a APIKEY] [-g]]
@@ -20,6 +20,7 @@ Options:
   --all                     all the things
   -c --config=CONFIG        CKAN configuration file for local actions,
                             defaults to ./development.ini if that file exists
+  -e --resources            load resources in a package
   -g --get-request          use GET instead of POST for API calls
   -i --input-json           read json from stdin to send to action
   -I --input=INPUT          input json/ json lines from file instead of stdin

--- a/ckanapi/cli/main.py
+++ b/ckanapi/cli/main.py
@@ -4,12 +4,12 @@ Usage:
   ckanapi action ACTION_NAME
           [KEY=VALUE ... | -i | -I JSON_INPUT] [-j | -J]
           [[-c CONFIG] [-u USER] | -r SITE_URL [-a APIKEY] [-g]]
-  ckanapi load (datasets)
-          [-I JSONL_INPUT] [-s START] [-m MAX] [-p PROCESSES] [-l LOG_FILE]
-          [--upload-resources] [-n | -o] [-qwz] [[-c CONFIG] [-u USER] | -r SITE_URL [-a APIKEY]]
+  ckanapi load datasets
+          [--upload-resources] [-I JSONL_INPUT] [-s START] [-m MAX] [-p PROCESSES]
+          [-l LOG_FILE] [-n | -o] [-qwz] [[-c CONFIG] [-u USER] | -r SITE_URL [-a APIKEY]]
   ckanapi load (groups | organizations)
-          [-I JSONL_INPUT] [-s START] [-m MAX] [-p PROCESSES] [-l LOG_FILE]
-          [--upload-logo] [-n | -o] [-qwz] [[-c CONFIG] [-u USER] | -r SITE_URL [-a APIKEY]]
+          [--upload-logo] [-I JSONL_INPUT] [-s START] [-m MAX] [-p PROCESSES] [-l LOG_FILE]
+          [-n | -o] [-qwz] [[-c CONFIG] [-u USER] | -r SITE_URL [-a APIKEY]]
   ckanapi load (users | related)
           [-I JSONL_INPUT] [-s START] [-m MAX] [-p PROCESSES] [-l LOG_FILE]
           [-n | -o] [-qwz] [[-c CONFIG] [-u USER] | -r SITE_URL [-a APIKEY]]
@@ -48,7 +48,7 @@ Options:
                             site sysadmin user when not specified
   --upload-logo             upload logo image of a group/organization if the
                             image is stored in the original server, otherwise
-                            tts image url will be used
+                            its image url will be used
   --upload-resources        upload resources of a dataset that were uploaded to
                             server. Resources originally linked by external
                             urls will keep the urls,will not be uploaded

--- a/ckanapi/cli/main.py
+++ b/ckanapi/cli/main.py
@@ -5,8 +5,8 @@ Usage:
           [KEY=VALUE ... | -i | -I JSON_INPUT] [-j | -J]
           [[-c CONFIG] [-u USER] | -r SITE_URL [-a APIKEY] [-g]]
   ckanapi load (datasets | groups | organizations | users | related)
-          [-I JSONL_INPUT] [-s START] [-m MAX] [-p PROCESSES] [-l LOG_FILE] [-e]
-          [-n | -o] [-qwz] [[-c CONFIG] [-u USER] | -r SITE_URL [-a APIKEY]] [--resources]
+          [-I JSONL_INPUT] [-s START] [-m MAX] [-p PROCESSES] [-l LOG_FILE] [--resources]
+          [-n | -o] [-qwz] [[-c CONFIG] [-u USER] | -r SITE_URL [-a APIKEY]]
   ckanapi dump (datasets | groups | organizations | users | related)
           (ID_OR_NAME ... | --all) ([-O JSONL_OUTPUT] | [-D DIRECTORY])
           [-p PROCESSES] [-qwz] [[-c CONFIG] [-u USER] | -r SITE_URL [-a APIKEY] [-g]]
@@ -20,7 +20,7 @@ Options:
   --all                     all the things
   -c --config=CONFIG        CKAN configuration file for local actions,
                             defaults to ./development.ini if that file exists
-  -e --resources            load resources in a package
+  --resources               load resources in a package
   -g --get-request          use GET instead of POST for API calls
   -i --input-json           read json from stdin to send to action
   -I --input=INPUT          input json/ json lines from file instead of stdin

--- a/ckanapi/cli/main.py
+++ b/ckanapi/cli/main.py
@@ -4,8 +4,14 @@ Usage:
   ckanapi action ACTION_NAME
           [KEY=VALUE ... | -i | -I JSON_INPUT] [-j | -J]
           [[-c CONFIG] [-u USER] | -r SITE_URL [-a APIKEY] [-g]]
-  ckanapi load (datasets | groups | organizations | users | related)
-          [-I JSONL_INPUT] [-s START] [-m MAX] [-p PROCESSES] [-l LOG_FILE] [--resources]
+  ckanapi load (datasets)
+          [-I JSONL_INPUT] [-s START] [-m MAX] [-p PROCESSES] [-l LOG_FILE]
+          [--upload-resources] [-n | -o] [-qwz] [[-c CONFIG] [-u USER] | -r SITE_URL [-a APIKEY]]
+  ckanapi load (groups | organizations)
+          [-I JSONL_INPUT] [-s START] [-m MAX] [-p PROCESSES] [-l LOG_FILE]
+          [--upload-logo] [-n | -o] [-qwz] [[-c CONFIG] [-u USER] | -r SITE_URL [-a APIKEY]]
+  ckanapi load (users | related)
+          [-I JSONL_INPUT] [-s START] [-m MAX] [-p PROCESSES] [-l LOG_FILE]
           [-n | -o] [-qwz] [[-c CONFIG] [-u USER] | -r SITE_URL [-a APIKEY]]
   ckanapi dump (datasets | groups | organizations | users | related)
           (ID_OR_NAME ... | --all) ([-O JSONL_OUTPUT] | [-D DIRECTORY])
@@ -20,7 +26,6 @@ Options:
   --all                     all the things
   -c --config=CONFIG        CKAN configuration file for local actions,
                             defaults to ./development.ini if that file exists
-  --resources               load resources in a package
   -g --get-request          use GET instead of POST for API calls
   -i --input-json           read json from stdin to send to action
   -I --input=INPUT          input json/ json lines from file instead of stdin
@@ -41,6 +46,12 @@ Options:
                             record is number 1 [default: 1]
   -u --ckan-user=USER       perform actions as user with this name, uses the
                             site sysadmin user when not specified
+  --upload-logo             upload logo image of a group/organization if the
+                            image is stored in the original server, otherwise
+                            tts image url will be used
+  --upload-resources        upload resources of a dataset that were uploaded to
+                            server. Resources originally linked by external
+                            urls will keep the urls,will not be uploaded
   -w --worker               launch worker process, used internally by load
                             and dump commands
   -z --gzip                 read/write gzipped data

--- a/ckanapi/tests/test_cli_load.py
+++ b/ckanapi/tests/test_cli_load.py
@@ -67,7 +67,7 @@ class TestCLILoad(unittest.TestCase):
         load_things_worker(self.ckan, 'datasets', {
                 '--create-only': False,
                 '--update-only': False,
-                '--resources':False,
+                '--upload-resources':False,
                 },
             stdin=BytesIO(b'{"name": "45","title":"Forty-five"}\n'),
             stdout=self.stdout)
@@ -82,7 +82,7 @@ class TestCLILoad(unittest.TestCase):
         load_things_worker(self.ckan, 'datasets', {
                 '--create-only': False,
                 '--update-only': False,
-                '--resources':False,
+                '--upload-resources':False,
                 },
             stdin=BytesIO(b'{"name": "45","title":"Forty-five","resources":[{"id":"123"}]}\n'),
             stdout=self.stdout)
@@ -97,10 +97,11 @@ class TestCLILoad(unittest.TestCase):
         load_things_worker(self.ckan, 'datasets', {
                 '--create-only': False,
                 '--update-only': False,
-                '--resources':False,
+                '--upload-resources':False,
                 },
-            stdin=BytesIO(b'{"name": "45","title":"Forty-five",\
-                            "resources":[{"id":"123","url_type":"","url":"http://datacats.com"}]}\n'),
+            stdin=BytesIO(
+                 b'{"name": "45","title":"Forty-five",'
+                 b'"resources":[{"id":"123","url_type":"","url":"http://example.com"}]}\n'),
             stdout=self.stdout)
         response = self.stdout.getvalue()
         self.assertEqual(response[-1:], b'\n')
@@ -113,7 +114,7 @@ class TestCLILoad(unittest.TestCase):
         load_things_worker(self.ckan, 'datasets', {
                 '--create-only': True,
                 '--update-only': False,
-                '--resources':False,
+                '--upload-resources':False,
                 },
             stdin=BytesIO(b'{"name": "45","title":"Forty-five"}\n'),
             stdout=self.stdout)
@@ -171,8 +172,9 @@ class TestCLILoad(unittest.TestCase):
                 '--create-only': False,
                 '--update-only': False,
                 },
-            stdin=BytesIO(b'{"name": "30ish","title":"3.4 times ten",\
-                            "resources":[{"id":"123","url_type":"","url":"http://datacats.com"}]}\n'),
+            stdin=BytesIO(
+                 b'{"name": "30ish","title":"3.4 times ten",'
+                 b'"resources":[{"id":"123","url_type":"","url":"http://example.com"}]}\n'),
             stdout=self.stdout)
         response = self.stdout.getvalue()
         self.assertEqual(response[-1:], b'\n')
@@ -303,7 +305,8 @@ class TestCLILoad(unittest.TestCase):
                 '--update-only': False,
                 '--start-record': '1',
                 '--max-records': None,
-                '--resources': False
+                '--upload-resources': False,
+                '--upload-logo':False
             },
             worker_pool=self._mock_worker_pool,
             stdin=BytesIO(
@@ -336,7 +339,8 @@ class TestCLILoad(unittest.TestCase):
                 '--update-only': False,
                 '--start-record': '2',
                 '--max-records': '2',
-                '--resources': False,
+                '--upload-resources': False,
+                '--upload-logo':False,
             },
             worker_pool=self._mock_worker_pool,
             stdin=BytesIO(
@@ -372,7 +376,8 @@ class TestCLILoad(unittest.TestCase):
                 '--update-only': False,
                 '--start-record': '1',
                 '--max-records': None,
-                '--resources': False,
+                '--upload-resources': False,
+                '--upload-logo':False,
             },
             worker_pool=self._mock_worker_pool,
             stdin=BytesIO(


### PR DESCRIPTION
Logo images are now automatically loaded when doing "ckanapi load groups/organizations".

Resources can be loaded when --resources option is specified. If not, then the original links will be mapped to new CKAN instance.