### PR TITLE
ASCII encoding breaks french accents in RemoteCKAN

### DIFF
--- a/ckanapi/common.py
+++ b/ckanapi/common.py
@@ -81,7 +81,7 @@ def prepare_action(action, data_dict=None, apikey=None, files=None):
                 v = unicode(v)
             data_dict[k.encode('utf-8')] = v.encode('utf-8')
     else:
-        data_dict = json.dumps(data_dict).encode('ascii')
+        data_dict = json.dumps(data_dict)
         headers['Content-Type'] = 'application/json'
     if apikey:
         apikey = str(apikey)


### PR DESCRIPTION
Updating datasets with RemoteCKAN.action.package_update breaks French accents.  Removing the ASCII encoding below fixes the problem for me.  
