### PR TITLE
Enable file uploads for LocalCKAN

### DIFF
--- a/ckanapi/localckan.py
+++ b/ckanapi/localckan.py
@@ -1,3 +1,6 @@
+import shutil
+import os
+from ckan.lib.uploader import ResourceUpload
 from ckanapi.errors import CKANAPIError
 from ckanapi.common import ActionShortcut
 
@@ -58,7 +61,6 @@ class LocalCKAN(object):
         else:
             resource = dict(data_dict)
 
-        from ckan.lib.uploader import ResourceUpload
         resource_upload = ResourceUpload({'id': resource['id']})
 
         # get first upload, ignore key

--- a/ckanapi/localckan.py
+++ b/ckanapi/localckan.py
@@ -1,6 +1,5 @@
 import shutil
 import os
-from ckan.lib.uploader import ResourceUpload
 from ckanapi.errors import CKANAPIError
 from ckanapi.common import ActionShortcut
 
@@ -16,7 +15,9 @@ class LocalCKAN(object):
     """
     def __init__(self, username=None, context=None):
         from ckan.logic import get_action
+        from ckan.lib.uploader import ResourceUpload
         self._get_action = get_action
+        self._ResourceUpload = ResourceUpload
 
         if username is None:
             username = self.get_site_username()
@@ -61,7 +62,7 @@ class LocalCKAN(object):
         else:
             resource = dict(data_dict)
 
-        resource_upload = ResourceUpload({'id': resource['id']})
+        resource_upload = self._ResourceUpload({'id': resource['id']})
 
         # get first upload, ignore key
         source_file = list(files.values())[0]

--- a/ckanapi/localckan.py
+++ b/ckanapi/localckan.py
@@ -64,7 +64,7 @@ class LocalCKAN(object):
         resource_upload = ResourceUpload({'id': resource['id']})
 
         # get first upload, ignore key
-        source_file = files.values()[0]
+        source_file = list(files.values())[0]
         if not resource_upload.storage_path:
             raise CKANAPIError("No storage configured, unable to upload files")
 
@@ -72,7 +72,7 @@ class LocalCKAN(object):
         filepath = resource_upload.get_path(resource['id'])
         try:
             os.makedirs(directory)
-        except OSError, e:
+        except OSError as e:
             ## errno 17 is file already exists
             if e.errno != 17:
                 raise

--- a/ckanapi/localckan.py
+++ b/ckanapi/localckan.py
@@ -57,10 +57,13 @@ class LocalCKAN(object):
         if action not in ['resource_create', 'resource_update']:
             raise CKANAPIError("LocalCKAN.call_action only supports file uploads for resources.")
 
+        new_data_dict = dict(data_dict)
         if action == 'resource_create':
-            resource = self._get_action(action)(dict(context), dict(data_dict))
+            if 'url' not in new_data_dict or not new_data_dict['url']:
+                new_data_dict['url'] = '/tmp-file' # url needs to be set, otherwise there is a ValidationError
+            resource = self._get_action(action)(dict(context), new_data_dict)
         else:
-            resource = dict(data_dict)
+            resource = new_data_dict
 
         resource_upload = self._ResourceUpload({'id': resource['id']})
 


### PR DESCRIPTION
The function signatur is similar to the RemoteCKAN. Files can be
uploaded using the `files` parameter. Currently only a single upload to
a resource is supported, but I guess this covers the main use case.