### PR TITLE
[#71] Sets default resource URL when uploading files

### DIFF
--- a/ckanapi/common.py
+++ b/ckanapi/common.py
@@ -69,6 +69,12 @@ def prepare_action(action, data_dict=None, apikey=None, files=None):
     if not data_dict:
         data_dict = {}
     headers = {}
+
+    # resource_create requires url, even if it's never used.
+    # https://github.com/ckan/ckan/issues/2769
+    if action == 'resource_create':
+        data_dict['url'] = data_dict.get('url', '')
+
     if files:
         # when uploading files all parameters must be strings and
         # no nesting is allowed because request is sent as multipart

--- a/ckanapi/tests/test_common.py
+++ b/ckanapi/tests/test_common.py
@@ -1,0 +1,19 @@
+import json
+import ckanapi.common
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
+
+
+class TestCommonPrepareAction(unittest.TestCase):
+    def test_resource_create_sets_default_url(self):
+        _, data_str, _ = ckanapi.common.prepare_action('resource_create')
+        data = json.loads(data_str.decode('utf-8'))
+        self.assertEqual(data['url'], '')
+
+    def test_resource_create_doesnt_overwrite_received_url(self):
+        _, data_str, _ = ckanapi.common.prepare_action('resource_create',
+                                                       {'url': 'foo'})
+        data = json.loads(data_str.decode('utf-8'))
+        self.assertEqual(data['url'], 'foo')


### PR DESCRIPTION
CKAN requires a "url" on "resource_create", even if it's not used (i.e. when
we're uploading a file). This might be solved in
https://github.com/ckan/ckan/issues/2769. To avoid making the user deal with
this problem, we deal with it ourselves.