### PR TITLE
Binary Mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,6 +208,10 @@ mysite.action.resource_create(
     package_id='my-dataset-with-files',
     upload=open('/path/to/file/to/upload.csv'))
 ```
+NOTE: Binary files (Zip, etc) may need to be opened in binary mode. In this case, the following code is required instead of the above;
+```
+    upload=open('/path/to/file/to/upload.csv','rb'))
+```
 
 When using `call_action` you must pass file objects separately:
 


### PR DESCRIPTION
Note requirement on some systems to open file in binary mode for certain data types. Zip files will not upload when specific binary values are present.

See https://github.com/OpenCouncilData/Ckan-Upload/issues/1