### PR TITLE
RemoteCKAN: use requests.Session

### DIFF
--- a/README.md
+++ b/README.md
@@ -271,9 +271,9 @@ mysite.call_action('resource_create',
 ### Session Control
 
 As of ckanapi 4.0 RemoteCKAN will keep your HTTP connection open using a
-(requests session)[http://docs.python-requests.org/en/master/user/advanced/].
+[requests session](http://docs.python-requests.org/en/master/user/advanced/).
 
-For long-running scripts you should make sure to close your connections by using
+For long-running scripts make sure to close your connections by using
 RemoteCKAN as a context manager:
 
 ```python
@@ -291,7 +291,7 @@ Or by explicitly calling `RemoteCKAN.close()`.
 
 A similar class is provided for accessing local CKAN instances from a plugin in
 the same way as remote CKAN instances.
-Unlike (CKAN's get_action)[http://docs.ckan.org/en/latest/extensions/plugins-toolkit.html?highlight=get_action#ckan.plugins.toolkit.get_action]
+Unlike [CKAN's get_action](http://docs.ckan.org/en/latest/extensions/plugins-toolkit.html?highlight=get_action#ckan.plugins.toolkit.get_action)
 LocalCKAN prevents data from one action
 call leaking into the next which can cause issues that are very hard do debug.
 

--- a/ckanapi/remoteckan.py
+++ b/ckanapi/remoteckan.py
@@ -34,6 +34,7 @@ class RemoteCKAN(object):
         self.address = address
         self.apikey = apikey
         self.get_only = get_only
+        self.session = None
         if not user_agent:
             user_agent = "ckanapi/{version} (+{url})".format(
                 version=__version__,
@@ -76,6 +77,8 @@ class RemoteCKAN(object):
         headers['User-Agent'] = self.user_agent
         url = self.address.rstrip('/') + '/' + url
         requests_kwargs = requests_kwargs or {}
+        if not self.session:
+            self.session = requests.Session()
         if self.get_only:
             status, response = self._request_fn_get(url, data_dict, headers, requests_kwargs)
         else:
@@ -83,7 +86,8 @@ class RemoteCKAN(object):
         return reverse_apicontroller_action(url, status, response)
 
     def _request_fn(self, url, data, headers, files, requests_kwargs):
-        r = requests.post(url, data=data, headers=headers, files=files, allow_redirects=False, **requests_kwargs)
+        r = self.session.post(url, data=data, headers=headers, files=files,
+            allow_redirects=False, **requests_kwargs)
         # allow_redirects=False because: if a post is redirected (e.g. 301 due
         # to a http to https redirect), then the second request is made to the
         # new URL, but *without* the data. This gives a confusing "No request
@@ -92,6 +96,18 @@ class RemoteCKAN(object):
         return r.status_code, r.text
 
     def _request_fn_get(self, url, data_dict, headers, requests_kwargs):
-        r = requests.get(url, params=data_dict, headers=headers, **requests_kwargs)
+        r = self.session.get(url, params=data_dict, headers=headers,
+            **requests_kwargs)
         return r.status_code, r.text
 
+    def close(self):
+        """Close session"""
+        if self.session:
+            self.session.close()
+            self.session = None
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self):
+        self.close()

--- a/ckanapi/remoteckan.py
+++ b/ckanapi/remoteckan.py
@@ -109,5 +109,5 @@ class RemoteCKAN(object):
     def __enter__(self):
         return self
 
-    def __exit__(self):
+    def __exit__(self, *args):
         self.close()

--- a/ckanapi/tests/test_remote.py
+++ b/ckanapi/tests/test_remote.py
@@ -5,7 +5,7 @@ import atexit
 import socket
 import requests
 
-import ckanapi
+from ckanapi import RemoteCKAN, NotFound
 try:
     import unittest2 as unittest
 except ImportError:
@@ -53,57 +53,68 @@ class TestRemoteAction(unittest.TestCase):
                 pass
             time.sleep(0.1)
 
-    def setUp(self):
-        self.ckan = ckanapi.RemoteCKAN(TEST_CKAN)
+    def test_good_oldstyle(self):
+        ckan = RemoteCKAN(TEST_CKAN)
+        self.assertEqual(
+            ckan.action.organization_list(),
+            ['aa', 'bb', 'cc'])
+        ckan.close()
 
     def test_good(self):
-        self.assertEqual(
-            self.ckan.action.organization_list(),
-            ['aa', 'bb', 'cc'])
+        with RemoteCKAN(TEST_CKAN) as ckan:
+            self.assertEqual(
+                ckan.action.organization_list(),
+                ['aa', 'bb', 'cc'])
 
     def test_missing(self):
-        self.assertRaises(
-            ckanapi.NotFound,
-            self.ckan.action.organization_show,
-            id='qqq')
+        with RemoteCKAN(TEST_CKAN) as ckan:
+            self.assertRaises(
+                NotFound,
+                ckan.action.organization_show,
+                id='qqq')
 
     def test_default_ua(self):
-        self.assertTrue(
-            self.ckan.action.test_echo_user_agent().startswith('ckanapi'))
+        with RemoteCKAN(TEST_CKAN) as ckan:
+            self.assertTrue(
+                ckan.action.test_echo_user_agent().startswith('ckanapi'))
 
     def test_custom_ua(self):
         ua = 'testckanapibot/1.0 (+https://github.com/ckan/ckanapi)'
-        ckan = ckanapi.RemoteCKAN('http://localhost:8901', user_agent=ua)
-
-        self.assertEqual(ckan.action.test_echo_user_agent(), ua)
+        with RemoteCKAN(TEST_CKAN, user_agent=ua) as ckan:
+            self.assertEqual(ckan.action.test_echo_user_agent(), ua)
 
     def test_default_content_type(self):
-        self.assertEqual(self.ckan.action.test_echo_content_type(),
-            "application/json")
+        with RemoteCKAN(TEST_CKAN) as ckan:
+            self.assertEqual(ckan.action.test_echo_content_type(),
+                "application/json")
 
     def test_resource_upload(self):
-        res = self.ckan.call_action('test_upload',
-            {'option': "42"},
-            files={'upload': StringIO(NUMBER_THING_CSV)})
+        with RemoteCKAN(TEST_CKAN) as ckan:
+            res = ckan.call_action('test_upload',
+                {'option': "42"},
+                files={'upload': StringIO(NUMBER_THING_CSV)})
         self.assertEqual(res.get('last_row'), ['5', 'sasquach'])
 
     def test_resource_upload_extra_param(self):
-        res = self.ckan.call_action('test_upload',
-            {'option': "42"},
-            files={'upload': StringIO(NUMBER_THING_CSV)})
+        with RemoteCKAN(TEST_CKAN) as ckan:
+            res = ckan.call_action('test_upload',
+                {'option': "42"},
+                files={'upload': StringIO(NUMBER_THING_CSV)})
         self.assertEqual(res.get('option'), "42")
 
     def test_resource_upload_unicode_param(self):
         uname = b't\xc3\xab\xc3\x9ft resource'.decode('utf-8')
-        res = self.ckan.call_action('test_upload',
-            {'option': uname},
-            files={'upload': StringIO(NUMBER_THING_CSV)})
+        with RemoteCKAN(TEST_CKAN) as ckan:
+            res = ckan.call_action('test_upload',
+                {'option': uname},
+                files={'upload': StringIO(NUMBER_THING_CSV)})
         self.assertEqual(res.get('option'), uname)
 
     def test_resource_upload_content_type(self):
-        res = self.ckan.call_action('test_echo_content_type',
-            {'option': "42"},
-            files={'upload': StringIO(NUMBER_THING_CSV)})
+        with RemoteCKAN(TEST_CKAN) as ckan:
+            res = ckan.call_action('test_echo_content_type',
+                {'option': "42"},
+                files={'upload': StringIO(NUMBER_THING_CSV)})
         self.assertEqual(res.split(';')[0], "multipart/form-data")
 
     @classmethod


### PR DESCRIPTION
Let's reuse a connection instead of making a new one for each action call.