### PR TITLE
[#103] Fix stdout and associated hang when doing dump -c

### DIFF
--- a/ckanapi/cli/dump.py
+++ b/ckanapi/cli/dump.py
@@ -135,7 +135,7 @@ def dump_things_worker(ckan, thing, arguments,
         except IOError:
             pass
     if stdout is None:
-        stdout = getattr(sys.stdout, 'buffer', sys.stdout)
+        stdout = getattr(sys.__stdout__, 'buffer', sys.__stdout__)
         # hack so that "print debugging" can work in extension/ckan
         # code called by this worker
         sys.stdout = sys.stderr


### PR DESCRIPTION
Fixes #103

Note: sys.__stdout__ is the original stdout and is documented here: https://docs.python.org/3.1/library/sys.html#sys.__stderr__
although I've only tested this on python 2.7.

