### PR TITLE
Fix python3 bug

### DIFF
--- a/ckanapi/cli/main.py
+++ b/ckanapi/cli/main.py
@@ -109,7 +109,7 @@ def main(running_with_paster=False):
             for r in action(ckan, arguments):
                 sys.stdout.write(r)
             return
-        except CLIError, e:
+        except CLIError as e:
             sys.stderr.write(e.args[0] + '\n')
             return 1
 


### PR DESCRIPTION
    Traceback (most recent call last):
      File "bin/ckanapi", line 11, in <module>
        load_entry_point('ckanapi', 'console_scripts', 'ckanapi')()
      File "lib/python3.5/site-packages/pkg_resources/__init__.py", line 542, in load_entry_point
        return get_distribution(dist).load_entry_point(group, name)
      File "lib/python3.5/site-packages/pkg_resources/__init__.py", line 2569, in load_entry_point
        return ep.load()
      File "lib/python3.5/site-packages/pkg_resources/__init__.py", line 2229, in load
        return self.resolve()
      File "lib/python3.5/site-packages/pkg_resources/__init__.py", line 2235, in resolve
        module = __import__(self.module_name, fromlist=['__name__'], level=0)
      File "ckanapi/ckanapi/cli/main.py", line 112
        except CLIError, e:
                       ^
    SyntaxError: invalid syntax