### PR TITLE
Make "dump users" work faster

### DIFF
--- a/ckanapi/cli/dump.py
+++ b/ckanapi/cli/dump.py
@@ -57,7 +57,10 @@ def dump_things(ckan, thing, arguments,
             'users': 'user_list',
             'related' :'related_list',
             }[thing]
-        names = ckan.call_action(get_thing_list, {})
+        params = dict(
+            all_fields=False,  # for user_list
+            )
+        names = ckan.call_action(get_thing_list, params)
 
     else:
         names = arguments['ID_OR_NAME']


### PR DESCRIPTION
Faster because it only gets the user names on user_list. Helps on latest ckan master only, following PR https://github.com/ckan/ckan/pull/3353

Harmless for other *_list actions.