### PR TITLE
e.message -> str(e.args[0]) if len(e.args) > 0 else ''

### DIFF
--- a/ckanapi/cli/dump.py
+++ b/ckanapi/cli/dump.py
@@ -195,7 +195,7 @@ def create_datapackage(record, base_path, stderr):
     try:
         os.makedirs(target_dir)
     except Exception as e:
-        stderr.write(e.message)
+        stderr.write(str(e.args[0]) if len(e.args) > 0 else '')
 
     for resource in record.get('resources', ''):
         if resource.get('name') is not None:
@@ -225,7 +225,7 @@ def create_datapackage(record, base_path, stderr):
         except requests.ConnectionError:
             stderr.write('URL {url} refused connection. The resource will not be downloaded\n'.format(url=resource['url']))
         except requests.exceptions.RequestException as e:
-            stderr.write(e.message)
+            stderr.write(str(e.args[0]) if len(e.args) > 0 else '')
             stderr.write('\n')
 
     json_output_name = '{base_path}/{dataset_name}/datapackage.json'.format(


### PR DESCRIPTION
As of recently tests fail with
```
ERROR: test_parent_datapackages (ckanapi.tests.test_cli_dump.TestCLIDump)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/vonwalha/git/ckanapi/ckanapi/tests/test_cli_dump.py", line 236, in test_parent_datapackages
    stderr=self.stderr)
  File "/home/vonwalha/git/ckanapi/ckanapi/cli/dump.py", line 109, in dump_things
    create_datapackage(record, datapackages_path, stderr)
  File "/home/vonwalha/git/ckanapi/ckanapi/cli/dump.py", line 228, in create_datapackage
    stderr.write(e.message)
TypeError: 'DecodeError' does not have the buffer interface
-------------------- >> begin captured logging << --------------------
requests.packages.urllib3.connectionpool: DEBUG: Starting new HTTP connection (1): example.com
requests.packages.urllib3.connectionpool: DEBUG: http://example.com:80 "GET /test-file HTTP/1.1" 404 466
--------------------- >> end captured logging << ---------------------
```

I could not figure out why this happens only now, but the reason appears to be usage of `stderr.write(e.message)`

`Exception.message` is deprecated since Python 2.6. Before it apparently was guaranteed to yield a string. See [PEP 352](https://www.python.org/dev/peps/pep-0352/). Now, `e.message` returns the first argument of the constructor of the exception (= `e.args[0]`) for backwards-compatibility. However that could be anything. In particular `requests` [raises exceptions](https://github.com/kennethreitz/requests/blob/master/requests/models.py#L721-L726)  that have another exception in `args[0]`, which results in the failure above.