### PR TITLE
Name resource files based on ID rather than URL or name (Fixes #113)

### DIFF
--- a/ckanapi/cli/dump.py
+++ b/ckanapi/cli/dump.py
@@ -180,58 +180,46 @@ def dump_things_worker(ckan, thing, arguments,
             reply('NotAuthorized')
 
 
+def create_resource(resource, datapackage_dir, stderr):
+    # Resources can have multiple sources with the same name, or names with
+    # filesystem-unfriendly characters, or URLs with a trailing slash, or
+    # multiple URLs with the same final path component, so we're just going to
+    # name all downloads using the resource's UID.
+    path = os.path.join('data', resource['id'])
+
+    try:
+        r = requests.get(resource['url'], stream=True)
+        with open(os.path.join(datapackage_dir, path), 'wb') as f:
+            for chunk in r.iter_content(chunk_size=DL_CHUNK_SIZE):
+                if chunk: # filter out keep-alive new chunks
+                    f.write(chunk)
+        return dict(resource, path=path)
+    except requests.ConnectionError:
+        stderr.write('URL {url} refused connection. The resource will not be downloaded\n'.format(url=resource['url']))
+    except requests.exceptions.RequestException as e:
+        stderr.write(str(e.args[0]) if len(e.args) > 0 else '')
+        stderr.write('\n')
+    except Exception as e:
+        stderr.write(str(e.args[0]) if len(e.args) > 0 else '')
+    return resource
+
+
 def create_datapackage(record, base_path, stderr):
     # TODO: how are we going to handle which resources to
     # leave alone? They're very inconsistent in some instances
     # And I can't imagine anyone wants to download a copy
     # of, for example, the API base endpoint
     resource_formats_to_ignore = ['API', 'api']
-    dataset_name = record.get('name', '') if record else ''
+    dataset_name = record.get('name', '')
 
-    target_dir = '{base_path}/{name}/data'.format(
-        base_path=base_path,
-        name=dataset_name)
+    datapackage_dir = os.path.join(base_path, dataset_name)
+    os.makedirs(os.path.join(datapackage_dir, 'data'))
 
-    try:
-        os.makedirs(target_dir)
-    except Exception as e:
-        stderr.write(str(e.args[0]) if len(e.args) > 0 else '')
+    resources = [(resource if resource['format'] in resource_formats_to_ignore else create_resource(resource, datapackage_dir, stderr)) for resource in record.get('resources', [])]
 
-    for resource in record.get('resources', ''):
-        if resource.get('name') is not None:
-            resource_id = resource['name']
-        else:
-            resource_id = resource['id']
-
-        resource_filename = os.path.split(resource['url'])[1]
-
-        output = os.path.join(target_dir, resource_filename)
-
-        # Resources can have a free-form address and no internal info, so in those cases
-        # we're going to merely save them using the UID. (If they even exist)
-        if output.endswith('/'):
-            output = os.path.join(output, resource_id)
-
-        resource['path'] = 'data' + output[len(target_dir):]
-
-        try:
-            if resource['format'] not in resource_formats_to_ignore:
-                r = requests.get(resource['url'], stream=True)
-                with open(output, 'wb') as f:
-                    for chunk in r.iter_content(chunk_size=DL_CHUNK_SIZE):
-                        if chunk: # filter out keep-alive new chunks
-                            f.write(chunk)
-                            f.flush()
-        except requests.ConnectionError:
-            stderr.write('URL {url} refused connection. The resource will not be downloaded\n'.format(url=resource['url']))
-        except requests.exceptions.RequestException as e:
-            stderr.write(str(e.args[0]) if len(e.args) > 0 else '')
-            stderr.write('\n')
-
-    json_output_name = '{base_path}/{dataset_name}/datapackage.json'.format(
-        base_path=base_path, dataset_name=dataset_name)
-    with open(json_output_name, 'wb') as out:
-        out.write(pretty_json(dict(record, version=DATAPACKAGE_VERSION)))
+    json_path = os.path.join(datapackage_dir, 'datapackage.json')
+    with open(json_path, 'wb') as out:
+        out.write(pretty_json(dict(record, resources=resources, version=DATAPACKAGE_VERSION)))
 
 
 def _worker_command_line(thing, arguments):

--- a/ckanapi/tests/test_cli_dump.py
+++ b/ckanapi/tests/test_cli_dump.py
@@ -34,6 +34,7 @@ class MockCKAN(object):
                         'title': 'Test for datapackage',
                         'resources':[
                             {'name': 'resource1',
+                             'id': 'd902fafc-5717-4dd0-87f2-7a6fc96989b7',
                              'format': 'html',
                              'url':'http://example.com/test-file'}]}
                     },
@@ -237,7 +238,7 @@ class TestCLIDump(unittest.TestCase):
             assert exists(target + '/twelve/datapackage.json')
             assert exists(target + '/thirtyfour/datapackage.json')
             assert exists(target + '/dp/datapackage.json')
-            assert exists(target + '/dp/data/test-file')
+            assert exists(target + '/dp/data/d902fafc-5717-4dd0-87f2-7a6fc96989b7')
         finally:
             shutil.rmtree(target)
 


### PR DESCRIPTION
Resources can have multiple sources with the same name, or names with filesystem-unfriendly characters, or URLs with a trailing slash, or multiple URLs with the same final path component, or URLs with filesystem-unfriendly names, so it's more reliable to name all downloads using the resource's `id` (or `name` if for some bizarre reason the resource has no `id` property).

That's what UIDs are for, anyway — avoiding potential duplicate-name conflicts or character set incompatibilities (no one wants `&`s in their filenames, or worse, newlines 😠 ).

Resolves #113.
