### PR TITLE
Coerce extra_msg to a string

### DIFF
--- a/ckanapi/errors.py
+++ b/ckanapi/errors.py
@@ -20,7 +20,7 @@ class CKANAPIError(Exception):
         self.extra_msg = extra_msg
 
     def __str__(self):
-        return self.extra_msg
+        return str(self.extra_msg)
 
 
 class CLIError(Exception):


### PR DESCRIPTION
Prior to this, `extra_msg` would be returned as whatever it was, resulting in errors like the following:

```
TypeError: __str__ returned non-string (type dict)
```