### PR TITLE
fix CLI output from API on Python 3

### DIFF
--- a/ckanapi/cli/main.py
+++ b/ckanapi/cli/main.py
@@ -107,7 +107,7 @@ def main(running_with_paster=False):
     if arguments['action']:
         try:
             for r in action(ckan, arguments):
-                sys.stdout.write(r)
+                sys.stdout.write(r.decode('utf-8'))
             return
         except CLIError as e:
             sys.stderr.write(e.args[0] + '\n')


### PR DESCRIPTION
This patch fixes this error under Python 3. The patch functions under Python 2.

```
$ ckanapi action group_list -r https://data.bioplatforms.com
Traceback (most recent call last):
  File "/home/gbowland/.virtual/bpa-ingest/bin/ckanapi", line 11, in <module>
    load_entry_point('ckanapi==4.0', 'console_scripts', 'ckanapi')()
  File "/home/gbowland/.virtual/bpa-ingest/lib/python3.5/site-packages/ckanapi/cli/main.py", line 110, in main
    sys.stdout.write(r)
TypeError: write() argument must be str, not bytes
```
