### PR TITLE
Describe RemoteCKAN's apikey parameter in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -223,6 +223,11 @@ All actions in the [CKAN Action API](http://docs.ckan.org/en/latest/api/index.ht
 and actions added by CKAN plugins are supported by action shortcuts and
 `call_action` calls.
 
+Many CKAN API functions can only be used by authenticated users. Use the
+`apikey` parameter to supply your CKAN API key to `RemoteCKAN`:
+
+    demo = RemoteCKAN('http://demo.ckan.org', apikey='MY-SECRET-API-KEY')
+
 
 ### Exceptions
 


### PR DESCRIPTION
This PR adds a small note regarding the `apikey` parameter of `RemoteCKAN` to the README. Right now, authentication is documented for the CLI but not for the Python module.