### PR TITLE
fix the bug that the str object has no decode in python3

### DIFF
--- a/ckanapi/cli/action.py
+++ b/ckanapi/cli/action.py
@@ -19,10 +19,12 @@ def action(ckan, arguments, stdin=None):
 
     file_args = {}
     if arguments['--input-json']:
-        action_args = json.loads(stdin.read().decode('utf-8'))
+        action_args = json.loads(
+            stdin.read().decode('utf-8') if sys.version_info.major == 2 else stdin.read())
     elif arguments['--input']:
-        action_args = json.loads(open(
-            expanduser(arguments['--input'])).read().decode('utf-8'))
+        with open(expanduser(arguments['--input'])) as in_f:
+            action_args = json.loads(
+                in_f.read().decode('utf-8') if sys.version_info.major == 2 else in_f.read())
     else:
         action_args = {}
         for kv in arguments['KEY=STRING']:


### PR DESCRIPTION
Traceback (most recent call last):
  File "/home/chuang/.local/bin/ckanapi", line 11, in <module>
    sys.exit(main())
  File
"/home/chuang/.local/lib/python3.6/site-packages/ckanapi/cli/main.py",
line 110, in main
    for r in action(ckan, arguments):
  File
"/home/chuang/.local/lib/python3.6/site-packages/ckanapi/cli/action.py",
line 25, in action
    expanduser(arguments['--input'])).read().decode('utf-8'))
AttributeError: 'str' object has no attribute 'decode'