### PR TITLE
Refactor datapackage, to work with ckanext-downloadall

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ $ ckanapi action group_list -r http://demo.ckan.org
   "example-group",
   "geo-examples",
   ...
-] 
+]
 ```
 
 Use -r to specify the remote CKAN instance, and -a to provide an
@@ -345,6 +345,13 @@ test_app = TestApp(...)
 demo = TestAppCKAN(test_app, apikey='my-test-key')
 groups = demo.action.group_list(id='data-explorer')
 ```
+
+
+## Tests
+
+To run the tests:
+
+  python setup.py test
 
 
 ## License

--- a/ckanapi/cli/dump.py
+++ b/ckanapi/cli/dump.py
@@ -173,7 +173,8 @@ def dump_things_worker(ckan, thing, arguments,
                 'include_password_hash': True,
                 })
             if thing == 'datasets' and arguments['--datastore-fields']:
-                populate_datastore_fields(ckan, obj)
+                for res in obj.get('resources', []):
+                    populate_datastore_fields(ckan, res)
         except NotFound:
             reply('NotFound')
         except NotAuthorized:

--- a/ckanapi/cli/dump.py
+++ b/ckanapi/cli/dump.py
@@ -13,7 +13,8 @@ from ckanapi.errors import (NotFound, NotAuthorized, ValidationError,
 from ckanapi.cli import workers
 from ckanapi.cli.utils import completion_stats, compact_json, \
     quiet_int_pipe
-from ckanapi.datapackage import create_datapackage, populate_datastore_fields
+from ckanapi.datapackage import create_datapackage, \
+    populate_datastore_res_fields
 
 
 def dump_things(ckan, thing, arguments,
@@ -174,7 +175,7 @@ def dump_things_worker(ckan, thing, arguments,
                 })
             if thing == 'datasets' and arguments['--datastore-fields']:
                 for res in obj.get('resources', []):
-                    populate_datastore_fields(ckan, res)
+                    populate_datastore_res_fields(ckan, res)
         except NotFound:
             reply('NotFound')
         except NotAuthorized:

--- a/ckanapi/datapackage.py
+++ b/ckanapi/datapackage.py
@@ -16,6 +16,8 @@ DATAPACKAGE_TYPES = {  # map datastore types to datapackage types
 
 
 def create_resource(resource, filename, datapackage_dir, stderr):
+    '''Downloads the resource['url'] to disk.
+    '''
     path = os.path.join('data', filename)
 
     try:
@@ -57,9 +59,8 @@ def create_datapackage(record, base_path, stderr):
     # get the datapackage (metadata)
     datapackage = dataset_to_datapackage(dataset)
 
-    existing_filenames = []
     for cres, dres in zip(ckan_resources, datapackage.get('resources', [])):
-        filename = resource_filename(dres, existing_filenames)
+        filename = resource_filename(dres)
 
         # download the resource
         cres = \
@@ -75,7 +76,7 @@ def create_datapackage(record, base_path, stderr):
     return datapackage_dir, datapackage, json_path
 
 
-def resource_filename(dres, existing_filenames):
+def resource_filename(dres):
     # prefer resource names from datapackage metadata, because those have been
     # made unique
     name = dres['name']

--- a/ckanapi/datapackage.py
+++ b/ckanapi/datapackage.py
@@ -16,10 +16,6 @@ DATAPACKAGE_TYPES = {  # map datastore types to datapackage types
 
 
 def create_resource(resource, filename, datapackage_dir, stderr):
-    # Resources can have multiple sources with the same name, or names with
-    # filesystem-unfriendly characters, or URLs with a trailing slash, or
-    # multiple URLs with the same final path component, so we're just going to
-    # name all downloads using the resource's UID.
     path = os.path.join('data', filename)
 
     try:
@@ -80,20 +76,13 @@ def create_datapackage(record, base_path, stderr):
 
 
 def resource_filename(dres, existing_filenames):
-    # prefer resource names from datapackage metadata
+    # prefer resource names from datapackage metadata, because those have been
+    # made unique
     name = dres['name']
     ext = slugify.slugify(dres['format'])
     if name.endswith(ext):
         name = name[:-len(ext)]
-    # deduplicate
-    add_ext = lambda x: x + '.' + ext
-    name_with_ext = add_ext(name)
-    if name_with_ext in existing_filenames:
-        for i in range(1e6):
-            name_with_ext = add_ext('{}_{}'.format(name, i))
-            if add_ext(name_with_ext) not in existing_filenames:
-                break
-    return name_with_ext
+    return name + '.' + ext
 
 
 def populate_schema_from_datastore(cres, dres):

--- a/ckanapi/datapackage.py
+++ b/ckanapi/datapackage.py
@@ -100,7 +100,7 @@ def populate_schema_from_datastore(cres, dres):
     """
     populate the data schema in a datapackage resource, from the Datastore.
     This info must already be added to the cres using
-    'populate_datastore_fields'
+    'populate_datastore_res_fields'
 
     :param cres: CKAN resource dict
     :param dres: datapackage.json style resource dict, for the same resource as
@@ -125,7 +125,7 @@ def populate_schema_from_datastore(cres, dres):
             fields.append(df)
         dres['schema'] = {'fields': fields}
 
-def populate_datastore_fields(ckan, res):
+def populate_datastore_res_fields(ckan, res):
     """
     update resource dict in-place with datastore_fields values
     in every resource with datastore active using ckan

--- a/ckanapi/tests/test_cli_datapackage.py
+++ b/ckanapi/tests/test_cli_datapackage.py
@@ -1,0 +1,168 @@
+from ckan.tests import factories
+from ckanapi.datapackage import dataset_to_datapackage
+
+try:
+    import unittest2 as unittest
+except ImportError:
+    import unittest
+
+
+class TestDatasetToDataPackage(unittest.TestCase):
+    def test_simple_dataset(self):
+        dataset_dict = {
+            u'extras': [{u'key': u'subject', u'value': u'science'}],
+            u'name': u'test_dataset_00',
+            u'notes': u'Just another test dataset.',
+            u'resources': [{
+                u'format': u'PNG',
+                u'name': u'Image 1',
+                u'url': u'http://example.com/image.png',
+                }],
+            u'tags': [{
+                u'display_name': u'science',
+                u'id': u'59f9359c-002b-4166-a519-755f89a631da',
+                u'name': u'science',
+            }],
+            u'title': u'Test Dataset',
+            u'type': u'dataset',
+        }
+
+        datapackage = dataset_to_datapackage(dataset_dict)
+
+        # code copied from test_package_show_with_full_dataset()
+        assert datapackage == {
+            'description': u'Just another test dataset.',
+            'extras': {u'subject': u'science'},
+            'keywords': [u'science'],
+            'name': u'test_dataset_00',
+            'resources': [{'format': u'PNG',
+                            'name': 'image-1',
+                            'path': u'http://example.com/image.png',
+                            'title': u'Image 1'}],
+            'title': u'Test Dataset'}
+
+    def test_full_dataset(self):
+        # This sample dataset_dict was generated in CKAN along the lines of
+        # ckan/tests/logic/action/test_get.py
+        # TestPackageShow.test_package_show_with_full_dataset()
+        dataset_dict = {
+            u'author': None,
+            u'author_email': None,
+            u'creator_user_id': u'3267d399-5517-47ef-ac02-13bb29372428',
+            u'extras': [{u'key': u'subject', u'value': u'science'}],
+            u'groups': [{u'description': u'A test description for this test group.',
+                        u'display_name': u'Test Group 00',
+                        u'id': u'cca3543f-0ba0-4194-b2f3-326498eb88b7',
+                        u'image_display_url': u'',
+                        u'name': u'test_group_00',
+                        u'title': u'Test Group 00'}],
+            u'id': u'a7165429-dde3-4a5f-ba7d-c690209200cf',
+            u'isopen': False,
+            u'license_id': None,
+            u'license_title': None,
+            u'maintainer': None,
+            u'maintainer_email': None,
+            u'metadata_created': u'2019-05-24T16:30:43.889152',
+            u'metadata_modified': u'2019-05-24T16:30:43.889161',
+            u'name': u'test_dataset_00',
+            u'notes': u'Just another test dataset.',
+            u'num_resources': 1,
+            u'num_tags': 1,
+            u'organization': {
+                u'approval_status': u'approved',
+                u'created': u'2019-05-24T16:30:43.608032',
+                u'description': u'Just another test organization.',
+                u'id': u'aa878f8c-1f6e-4e87-b08e-67272d9c3d16',
+                u'image_url': u'http://placekitten.com/g/200/100',
+                u'is_organization': True,
+                u'name': u'test_org_00',
+                u'revision_id': u'bb31cfee-aee9-4031-9333-ed922bf3f049',
+                u'state': u'active',
+                u'title': u'Test Organization',
+                u'type': u'organization'},
+            u'owner_org': u'aa878f8c-1f6e-4e87-b08e-67272d9c3d16',
+            u'private': False,
+            u'relationships_as_object': [],
+            u'relationships_as_subject': [],
+            u'resources': [{
+                u'cache_last_updated': None,
+                u'cache_url': None,
+                u'created': u'2019-05-24T16:30:43.894623',
+                u'description': u'',
+                u'format': u'PNG',
+                u'hash': u'',
+                u'id': u'a8e2f627-0450-4728-a0a4-ed3a091c303c',
+                u'last_modified': None,
+                u'mimetype': None,
+                u'mimetype_inner': None,
+                u'name': u'Image 1',
+                u'package_id': u'a7165429-dde3-4a5f-ba7d-c690209200cf',
+                u'position': 0,
+                u'resource_type': None,
+                u'revision_id': u'990df889-690c-412e-a7ad-f848c9927218',
+                u'size': None,
+                u'state': u'active',
+                u'url': u'http://example.com/image.png',
+                u'url_type': None}],
+            u'revision_id': u'990df889-690c-412e-a7ad-f848c9927218',
+            u'state': u'active',
+            u'tags': [{
+                u'display_name': u'science',
+                u'id': u'59f9359c-002b-4166-a519-755f89a631da',
+                u'name': u'science',
+                u'state': u'active',
+                u'vocabulary_id': None}],
+            u'title': u'Test Dataset',
+            u'type': u'dataset',
+            u'url': None,
+            u'version': None
+        }
+
+        datapackage = dataset_to_datapackage(dataset_dict)
+
+        assert datapackage == {
+            'description': u'Just another test dataset.',
+            'extras': {u'subject': u'science'},
+            'keywords': [u'science'],
+            'name': u'test_dataset_00',
+            'resources': [{'format': u'PNG',
+                            'name': 'image-1',
+                            'path': u'http://example.com/image.png',
+                            'title': u'Image 1'}],
+            'title': u'Test Dataset'}
+
+    def test_resource_names_are_unique(self):
+        # Somehow these resources got the same name
+        dataset_dict = {
+            u'name': u'test_dataset_00',
+            u'notes': u'Just another test dataset.',
+            u'resources': [
+                {
+                    u'format': u'PNG',
+                    u'name': u'Image',
+                    u'url': u'http://example.com/imageA.png',
+                },
+                {
+                    u'format': u'PNG',
+                    u'name': u'Image',
+                    u'url': u'http://example.com/imageB.png',
+                },
+                {
+                    u'format': u'PNG',
+                    u'name': u'Image',
+                    u'url': u'http://example.com/imageC.png',
+                },
+                ],
+            u'tags': [{
+                u'display_name': u'science',
+                u'id': u'59f9359c-002b-4166-a519-755f89a631da',
+                u'name': u'science',
+            }],
+            u'title': u'Test Dataset',
+            u'type': u'dataset',
+        }
+
+        datapackage = dataset_to_datapackage(dataset_dict)
+
+        assert [res['name'] for res in datapackage['resources']] == \
+            [u'image', u'image0', u'image1']

--- a/ckanapi/tests/test_cli_datapackage.py
+++ b/ckanapi/tests/test_cli_datapackage.py
@@ -1,10 +1,15 @@
 from ckan.tests import factories
-from ckanapi.datapackage import dataset_to_datapackage
+from ckanapi.datapackage import (
+    dataset_to_datapackage, create_resource, create_datapackage,
+    resource_filename, populate_schema_from_datastore)
 
 try:
     import unittest2 as unittest
 except ImportError:
     import unittest
+from io import BytesIO
+import os
+from pyfakefs import fake_filesystem_unittest
 
 
 class TestDatasetToDataPackage(unittest.TestCase):
@@ -31,15 +36,15 @@ class TestDatasetToDataPackage(unittest.TestCase):
 
         # code copied from test_package_show_with_full_dataset()
         assert datapackage == {
-            'description': u'Just another test dataset.',
-            'extras': {u'subject': u'science'},
-            'keywords': [u'science'],
-            'name': u'test_dataset_00',
-            'resources': [{'format': u'PNG',
-                            'name': 'image-1',
-                            'path': u'http://example.com/image.png',
-                            'title': u'Image 1'}],
-            'title': u'Test Dataset'}
+            u'description': u'Just another test dataset.',
+            u'extras': {u'subject': u'science'},
+            u'keywords': [u'science'],
+            u'name': u'test_dataset_00',
+            u'resources': [{u'format': u'PNG',
+                            u'name': u'image-1',
+                            u'path': u'http://example.com/image.png',
+                            u'title': u'Image 1'}],
+            u'title': u'Test Dataset'}
 
     def test_full_dataset(self):
         # This sample dataset_dict was generated in CKAN along the lines of
@@ -121,15 +126,15 @@ class TestDatasetToDataPackage(unittest.TestCase):
         datapackage = dataset_to_datapackage(dataset_dict)
 
         assert datapackage == {
-            'description': u'Just another test dataset.',
-            'extras': {u'subject': u'science'},
-            'keywords': [u'science'],
-            'name': u'test_dataset_00',
-            'resources': [{'format': u'PNG',
-                            'name': 'image-1',
-                            'path': u'http://example.com/image.png',
-                            'title': u'Image 1'}],
-            'title': u'Test Dataset'}
+            u'description': u'Just another test dataset.',
+            u'extras': {u'subject': u'science'},
+            u'keywords': [u'science'],
+            u'name': u'test_dataset_00',
+            u'resources': [{u'format': u'PNG',
+                            u'name': u'image-1',
+                            u'path': u'http://example.com/image.png',
+                            u'title': u'Image 1'}],
+            u'title': u'Test Dataset'}
 
     def test_resource_names_are_unique(self):
         # Somehow these resources got the same name
@@ -166,3 +171,141 @@ class TestDatasetToDataPackage(unittest.TestCase):
 
         assert [res['name'] for res in datapackage['resources']] == \
             [u'image', u'image0', u'image1']
+
+
+class TestCreateResource(fake_filesystem_unittest.TestCase):
+    def setUp(self):
+        self.setUpPyfakefs()
+
+    def test_simple(self):
+        resource = {
+            u'format': u'PNG',
+            u'name': u'Image',
+            u'url': u'http://example.com/image.png',
+        }
+        filename = 'image_saved.png'
+        os.makedirs('/test/data')
+        stderr = BytesIO()
+        # TODO mock the HTTP request to example.com
+
+        returned_resource = create_resource(
+            resource, filename='image_saved.png',
+            datapackage_dir='/test', stderr=stderr)
+
+        stderr.seek(0)
+        assert not stderr.read()
+        assert returned_resource == {
+            u'url': u'http://example.com/image.png',
+            u'name': u'Image',
+            u'format': u'PNG',
+            u'path': u'data/image_saved.png',
+        }
+
+
+class TestCreateDataPackage(fake_filesystem_unittest.TestCase):
+    def setUp(self):
+        self.setUpPyfakefs()
+
+    def test_simple(self):
+        dataset = {
+            u'extras': [{u'key': u'subject', u'value': u'science'}],
+            u'name': u'test_dataset_00',
+            u'notes': u'Just another test dataset.',
+            u'resources': [{
+                u'format': u'PNG',
+                u'name': u'Image 1',
+                u'url': u'http://example.com/image.png',
+                }],
+            u'tags': [{
+                u'display_name': u'science',
+                u'id': u'59f9359c-002b-4166-a519-755f89a631da',
+                u'name': u'science',
+            }],
+            u'title': u'Test Dataset',
+            u'type': u'dataset',
+        }
+        stderr = BytesIO()
+        os.makedirs('/test/data')
+        # TODO mock the HTTP request to example.com
+
+        datapackage_dir, datapackage, json_path = \
+            create_datapackage(record=dataset, base_path='/test/',
+                               stderr=stderr)
+
+        stderr.seek(0)
+        assert not stderr.read()
+        assert datapackage_dir == u'/test/test_dataset_00'
+        assert datapackage == {
+            u'name': u'test_dataset_00',
+            u'description': u'Just another test dataset.',
+            u'title': u'Test Dataset',
+            u'extras': {u'subject': u'science'},
+            u'keywords': [u'science'],
+            u'resources': [{
+                u'path': u'data/image-1.png',  # i.e. it was downloaded
+                u'title': u'Image 1',
+                u'name': u'image-1',
+                u'format': u'PNG'}],
+        }
+        assert json_path == u'/test/test_dataset_00/datapackage.json'
+
+
+class TestResourceFilename(unittest.TestCase):
+    def test_simple(self):
+        datapackage_resource = {
+            u'title': u'Image 1',
+            u'name': u'image-1',
+            u'format': u'PNG'
+        }
+
+        filename = resource_filename(dres=datapackage_resource)
+
+        assert filename == u'image-1.png'
+
+
+class TestPopulateSchemaFromDatastore(unittest.TestCase):
+    def test_simple(self):
+        ckan_resource = {
+            u'format': u'CSV',
+            u'name': u'Buildings 1',
+            u'url': u'http://example.com/buildings.csv',
+            # example datastore fields from:
+            # curl 'https://data.boston.gov/api/3/action/datastore_search?resource_id=28ca9f8d-f6ad-4855-bf14-90d2d0bc85ca&limit=0' |jq '.result.fields'
+            u'datastore_fields': [
+                {
+                    u'id': u'country',
+                    u'type': u'int',
+                    u'info': {
+                        u'label': u'The country',
+                        u'notes': u'iso code',
+                    }
+                },
+                {
+                    u'id': u'NUM_FLOORS',
+                    u'type': u'text',
+                    u'info': {
+                        u'type_override': {}
+                    },
+                }
+            ]
+        }
+        datapackage_resource = {
+            u'title': u'Buildings 1',
+            u'name': u'buildings-1',
+            u'format': u'CSV'
+        }
+
+        populate_schema_from_datastore(cres=ckan_resource,
+                                       dres=datapackage_resource)
+
+        assert datapackage_resource == {
+            u'title': u'Buildings 1',
+            u'name': u'buildings-1',
+            u'format': u'CSV',
+            u'schema': {'fields': [{'description': u'iso code',
+                                    'name': u'country',
+                                    'title': u'The country'},
+                                   {'name': u'NUM_FLOORS',
+                                    'type': 'string'}]
+            }
+        }

--- a/ckanapi/tests/test_datapackage.py
+++ b/ckanapi/tests/test_datapackage.py
@@ -1,4 +1,3 @@
-from ckan.tests import factories
 from ckanapi.datapackage import (
     dataset_to_datapackage, create_resource, create_datapackage,
     resource_filename, populate_schema_from_datastore)

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,9 @@ install_requires=[
     'python-slugify>=1.0,<2.0',
     'six>=1.9,<2.0',
 ]
+tests_require=[
+    'pyfakefs',
+]
 
 if sys.version_info <= (3,):
     install_requires.append('simplejson')
@@ -33,6 +36,7 @@ setup(
         'ckanapi.cli',
         ],
     install_requires=install_requires,
+    tests_require=tests_require,
     test_suite='ckanapi.tests',
     zip_safe=False,
     entry_points = """


### PR DESCRIPTION
I've factored out a couple of funcs, for use by ckanext-download: https://github.com/davidread/ckanext-downloadall/pull/3

TODO
* [ ] Revert `populate_datastore_fields` alone after
* [ ] Unit tests for the new funcs