### PR TITLE
Add Option to Disable Certificate Verification at Command Line 

### DIFF
--- a/ckanapi/cli/action.py
+++ b/ckanapi/cli/action.py
@@ -19,7 +19,7 @@ def action(ckan, arguments, stdin=None):
 
     file_args = {}
     requests_kwargs = None
-    if arguments['--no-verify']:
+    if arguments['--insecure']:
         requests_kwargs = {'verify': False}
     if arguments['--input-json']:
         action_args = json.loads(stdin.read().decode('utf-8'))

--- a/ckanapi/cli/action.py
+++ b/ckanapi/cli/action.py
@@ -18,6 +18,9 @@ def action(ckan, arguments, stdin=None):
         stdin = getattr(sys.stdin, 'buffer', sys.stdin)
 
     file_args = {}
+    requests_kwargs = None
+    if arguments['--no-verify']:
+        requests_kwargs = {'verify': False}
     if arguments['--input-json']:
         action_args = json.loads(stdin.read().decode('utf-8'))
     elif arguments['--input']:
@@ -54,7 +57,7 @@ def action(ckan, arguments, stdin=None):
                     "KEY:JSON or KEY@FILE %r" % kv)
 
     result = ckan.call_action(arguments['ACTION_NAME'], action_args,
-        files=file_args)
+                              files=file_args, requests_kwargs=requests_kwargs)
 
     if arguments['--output-jsonl']:
         if isinstance(result, list):

--- a/ckanapi/cli/delete.py
+++ b/ckanapi/cli/delete.py
@@ -207,7 +207,11 @@ def delete_things_worker(ckan, thing, arguments,
             continue
 
         try:
-            ckan.call_action(thing_delete, {'id': name})
+            requests_kwargs = None
+            if arguments['--insecure']:
+                requests_kwargs = {'verify': False}
+            ckan.call_action(thing_delete, {'id': name},
+                             requests_kwargs=requests_kwargs)
         except NotAuthorized as e:
             reply('NotAuthorized', unicode(e))
         except NotFound:

--- a/ckanapi/cli/dump.py
+++ b/ckanapi/cli/dump.py
@@ -169,10 +169,13 @@ def dump_things_worker(ckan, thing, arguments,
             continue
 
         try:
+            requests_kwargs = None
+            if arguments['--insecure']:
+                requests_kwargs = {'verify': False}
             obj = ckan.call_action(thing_show, {'id': name,
                 'include_datasets': False,
                 'include_password_hash': True,
-                })
+                }, requests_kwargs=requests_kwargs)
         except NotFound:
             reply('NotFound')
         except NotAuthorized:

--- a/ckanapi/cli/main.py
+++ b/ckanapi/cli/main.py
@@ -4,7 +4,7 @@ Usage:
   ckanapi action ACTION_NAME
           [(KEY=STRING | KEY:JSON | KEY@FILE ) ... | -i | -I JSON_INPUT]
           [-j | -J] [[-c CONFIG] [-u USER] | -r SITE_URL [-a APIKEY] [-g]]
-          [--no-verify]
+          [--insecure]
   ckanapi load datasets
           [--upload-resources] [-I JSONL_INPUT] [-s START] [-m MAX]
           [-p PROCESSES] [-l LOG_FILE] [-n | -o] [-qwz]
@@ -47,7 +47,7 @@ Options:
   -l --log=LOG_FILE         append messages generated to LOG_FILE
   -m --max-records=MAX      exit after processing MAX records
   -n --create-only          create new records, don't update existing records
-  --no-verify               ignore verifying the SSL certificate for sites
+  --insecure               ignore verifying the SSL certificate for sites
                             using https
   -o --update-only          update existing records, don't create new records
   -O --output=JSONL_OUTPUT  output to json lines file instead of stdout

--- a/ckanapi/cli/main.py
+++ b/ckanapi/cli/main.py
@@ -9,21 +9,26 @@ Usage:
           [--upload-resources] [-I JSONL_INPUT] [-s START] [-m MAX]
           [-p PROCESSES] [-l LOG_FILE] [-n | -o] [-qwz]
           [[-c CONFIG] [-u USER] | -r SITE_URL [-a APIKEY]]
+          [--insecure]
   ckanapi load (groups | organizations)
           [--upload-logo] [-I JSONL_INPUT] [-s START] [-m MAX]
           [-p PROCESSES] [-l LOG_FILE] [-n | -o] [-qwz]
           [[-c CONFIG] [-u USER] | -r SITE_URL [-a APIKEY]]
+          [--insecure]
   ckanapi load (users | related)
           [-I JSONL_INPUT] [-s START] [-m MAX] [-p PROCESSES] [-l LOG_FILE]
           [-n | -o] [-qwz] [[-c CONFIG] [-u USER] | -r SITE_URL [-a APIKEY]]
+          [--insecure]
   ckanapi dump (datasets | groups | organizations | users | related)
           (ID_OR_NAME ... | --all) ([-O JSONL_OUTPUT] | [-D DIRECTORY])
           [-p PROCESSES] [-dqwz]
           [[-c CONFIG] [-u USER] | -r SITE_URL [-a APIKEY] [-g]]
+          [--insecure]
   ckanapi delete (datasets | groups | organizations | users | related)
           (ID_OR_NAME ... | [-I JSONL_INPUT] [-s START] [-m MAX])
           [-p PROCESSES] [-l LOG_FILE] [-qwz]
           [[-c CONFIG] [-u USER] | -r SITE_URL [-a APIKEY]]
+          [--insecure]
   ckanapi (-h | --help)
   ckanapi --version
 
@@ -47,7 +52,7 @@ Options:
   -l --log=LOG_FILE         append messages generated to LOG_FILE
   -m --max-records=MAX      exit after processing MAX records
   -n --create-only          create new records, don't update existing records
-  --insecure               ignore verifying the SSL certificate for sites
+  --insecure                ignore verifying the SSL certificate for sites
                             using https
   -o --update-only          update existing records, don't create new records
   -O --output=JSONL_OUTPUT  output to json lines file instead of stdout

--- a/ckanapi/cli/main.py
+++ b/ckanapi/cli/main.py
@@ -4,6 +4,7 @@ Usage:
   ckanapi action ACTION_NAME
           [(KEY=STRING | KEY:JSON | KEY@FILE ) ... | -i | -I JSON_INPUT]
           [-j | -J] [[-c CONFIG] [-u USER] | -r SITE_URL [-a APIKEY] [-g]]
+          [--no-verify]
   ckanapi load datasets
           [--upload-resources] [-I JSONL_INPUT] [-s START] [-m MAX]
           [-p PROCESSES] [-l LOG_FILE] [-n | -o] [-qwz]
@@ -46,6 +47,8 @@ Options:
   -l --log=LOG_FILE         append messages generated to LOG_FILE
   -m --max-records=MAX      exit after processing MAX records
   -n --create-only          create new records, don't update existing records
+  --no-verify               ignore verifying the SSL certificate for sites
+                            using https
   -o --update-only          update existing records, don't create new records
   -O --output=JSONL_OUTPUT  output to json lines file instead of stdout
   -p --processes=PROCESSES  set the number of worker processes [default: 1]

--- a/ckanapi/tests/test_cli_action.py
+++ b/ckanapi/tests/test_cli_action.py
@@ -38,7 +38,7 @@ class TestCLIAction(unittest.TestCase):
             '--output-jsonl': False,
             '--input-json': False,
             '--input': None,
-            '--no-verify': False
+            '--insecure': False
             })
         self.assertEqual(b''.join(rval), b"""
 {
@@ -58,7 +58,7 @@ class TestCLIAction(unittest.TestCase):
             '--output-jsonl': False,
             '--input-json': False,
             '--input': None,
-            '--no-verify': False
+            '--insecure': False
             })
         self.assertEqual(b''.join(rval), b'["right","on"]\n')
 
@@ -71,7 +71,7 @@ class TestCLIAction(unittest.TestCase):
             '--output-jsonl': True,
             '--input-json': False,
             '--input': None,
-            '--no-verify': False
+            '--insecure': False
             })
         self.assertEqual(b''.join(rval), b'{"oh":["right","on"]}\n')
 
@@ -84,7 +84,7 @@ class TestCLIAction(unittest.TestCase):
             '--output-jsonl': True,
             '--input-json': False,
             '--input': None,
-            '--no-verify': False
+            '--insecure': False
             })
         self.assertEqual(b''.join(rval), b'99\n98\n97\n')
 
@@ -97,7 +97,7 @@ class TestCLIAction(unittest.TestCase):
                 '--output-jsonl': False,
                 '--input-json': True,
                 '--input': None,
-                '--no-verify': False
+                '--insecure': False
             },
             stdin=BytesIO(b'{"who":["just","me"]}'),
             )
@@ -112,7 +112,7 @@ class TestCLIAction(unittest.TestCase):
             '--output-jsonl': False,
             '--input-json': False,
             '--input': None,
-            '--no-verify': False
+            '--insecure': False
             })
         self.assertEqual(b''.join(rval), b'"yeah"\n')
 
@@ -125,7 +125,7 @@ class TestCLIAction(unittest.TestCase):
             '--output-jsonl': False,
             '--input-json': False,
             '--input': None,
-            '--no-verify': False
+            '--insecure': False
             })
         self.assertRaises(CLIError, list, rval)
 
@@ -138,7 +138,7 @@ class TestCLIAction(unittest.TestCase):
             '--output-jsonl': False,
             '--input-json': False,
             '--input': None,
-            '--no-verify': False
+            '--insecure': False
             })
         self.assertRaises(CLIError, list, rval)
 
@@ -151,7 +151,7 @@ class TestCLIAction(unittest.TestCase):
             '--output-jsonl': False,
             '--input-json': False,
             '--input': None,
-            '--no-verify': False
+            '--insecure': False
             })
         self.assertEqual(b''.join(rval), b'"yeah"\n')
 
@@ -164,6 +164,6 @@ class TestCLIAction(unittest.TestCase):
             '--output-jsonl': False,
             '--input-json': False,
             '--input': None,
-            '--no-verify': False
+            '--insecure': False
             })
         self.assertEqual(b''.join(rval), b'"yeah"\n')

--- a/ckanapi/tests/test_cli_action.py
+++ b/ckanapi/tests/test_cli_action.py
@@ -37,6 +37,7 @@ class TestCLIAction(unittest.TestCase):
             '--output-jsonl': False,
             '--input-json': False,
             '--input': None,
+            '--no-verify': False
             })
         self.assertEqual(b''.join(rval), b"""
 {
@@ -56,6 +57,7 @@ class TestCLIAction(unittest.TestCase):
             '--output-jsonl': False,
             '--input-json': False,
             '--input': None,
+            '--no-verify': False
             })
         self.assertEqual(b''.join(rval), b'["right","on"]\n')
 
@@ -68,6 +70,7 @@ class TestCLIAction(unittest.TestCase):
             '--output-jsonl': True,
             '--input-json': False,
             '--input': None,
+            '--no-verify': False
             })
         self.assertEqual(b''.join(rval), b'{"oh":["right","on"]}\n')
 
@@ -80,6 +83,7 @@ class TestCLIAction(unittest.TestCase):
             '--output-jsonl': True,
             '--input-json': False,
             '--input': None,
+            '--no-verify': False
             })
         self.assertEqual(b''.join(rval), b'99\n98\n97\n')
 
@@ -92,6 +96,7 @@ class TestCLIAction(unittest.TestCase):
                 '--output-jsonl': False,
                 '--input-json': True,
                 '--input': None,
+                '--no-verify': False
             },
             stdin=BytesIO(b'{"who":["just","me"]}'),
             )
@@ -106,6 +111,7 @@ class TestCLIAction(unittest.TestCase):
             '--output-jsonl': False,
             '--input-json': False,
             '--input': None,
+            '--no-verify': False
             })
         self.assertEqual(b''.join(rval), b'"yeah"\n')
 
@@ -118,6 +124,7 @@ class TestCLIAction(unittest.TestCase):
             '--output-jsonl': False,
             '--input-json': False,
             '--input': None,
+            '--no-verify': False
             })
         self.assertRaises(CLIError, list, rval)
 
@@ -130,6 +137,7 @@ class TestCLIAction(unittest.TestCase):
             '--output-jsonl': False,
             '--input-json': False,
             '--input': None,
+            '--no-verify': False
             })
         self.assertRaises(CLIError, list, rval)
 
@@ -142,6 +150,7 @@ class TestCLIAction(unittest.TestCase):
             '--output-jsonl': False,
             '--input-json': False,
             '--input': None,
+            '--no-verify': False
             })
         self.assertEqual(b''.join(rval), b'"yeah"\n')
 
@@ -154,5 +163,6 @@ class TestCLIAction(unittest.TestCase):
             '--output-jsonl': False,
             '--input-json': False,
             '--input': None,
+            '--no-verify': False
             })
         self.assertEqual(b''.join(rval), b'"yeah"\n')

--- a/ckanapi/tests/test_cli_action.py
+++ b/ckanapi/tests/test_cli_action.py
@@ -16,7 +16,8 @@ class MockCKAN(object):
         self._expected_files = expected_files or {}
         self._response = response
 
-    def call_action(self, name, args, context=None, apikey=None, files=None):
+    def call_action(self, name, args, context=None, apikey=None, files=None,
+                    requests_kwargs=None):
         if name != self._expected_name:
             return ["wrong name", name, self._expected_name]
         if args != self._expected_args:

--- a/ckanapi/tests/test_cli_dump.py
+++ b/ckanapi/tests/test_cli_dump.py
@@ -13,7 +13,7 @@ from io import BytesIO
 
 
 class MockCKAN(object):
-    def call_action(self, name, data_dict):
+    def call_action(self, name, data_dict, requests_kwargs=None):
         try:
             return {
                 'package_list': {
@@ -63,7 +63,8 @@ class TestCLIDump(unittest.TestCase):
 
     def test_worker_one(self):
         rval = dump_things_worker(self.ckan, 'datasets',
-            {'--datastore-fields': False},
+            {'--datastore-fields': False,
+             '--insecure': False},
             stdin=BytesIO(b'"34"\n'), stdout=self.stdout)
         response = self.stdout.getvalue()
         self.assertEqual(response[-1:], b'\n')
@@ -73,7 +74,8 @@ class TestCLIDump(unittest.TestCase):
 
     def test_worker_two(self):
         rval = dump_things_worker(self.ckan, 'datasets',
-            {'--datastore-fields': False},
+            {'--datastore-fields': False,
+             '--insecure': False},
             stdin=BytesIO(b'"12"\n"34"\n'), stdout=self.stdout)
         response = self.stdout.getvalue()
         self.assertEqual(response.count(b'\n'), 2, response)
@@ -87,7 +89,8 @@ class TestCLIDump(unittest.TestCase):
         self.assertEqual(data["title"], "Thirty-four")
 
     def test_worker_error(self):
-        dump_things_worker(self.ckan, 'datasets', {},
+        dump_things_worker(self.ckan, 'datasets',
+            {'--insecure': False},
             stdin=BytesIO(b'"99"\n'), stdout=self.stdout)
         response = self.stdout.getvalue()
         self.assertEqual(response[-1:], b'\n')
@@ -96,7 +99,8 @@ class TestCLIDump(unittest.TestCase):
         self.assertEqual(data, None)
 
     def test_worker_group(self):
-        dump_things_worker(self.ckan, 'groups', {},
+        dump_things_worker(self.ckan, 'groups',
+            {'--insecure': False},
             stdin=BytesIO(b'"ab"\n'), stdout=self.stdout)
         response = self.stdout.getvalue()
         self.assertEqual(response[-1:], b'\n')
@@ -105,7 +109,8 @@ class TestCLIDump(unittest.TestCase):
         self.assertEqual(data, {"title":"ABBA"})
 
     def test_worker_organization(self):
-        dump_things_worker(self.ckan, 'organizations', {},
+        dump_things_worker(self.ckan, 'organizations',
+            {'--insecure': False},
             stdin=BytesIO(b'"cd"\n'), stdout=self.stdout)
         response = self.stdout.getvalue()
         self.assertEqual(response[-1:], b'\n')
@@ -129,6 +134,7 @@ class TestCLIDump(unittest.TestCase):
                 '--processes': '1',
                 '--get-request': False,
                 '--datastore-fields': False,
+                '--insecure': False
             },
             worker_pool=self._mock_worker_pool,
             stdout=self.stdout,
@@ -158,6 +164,7 @@ class TestCLIDump(unittest.TestCase):
                 '--processes': '5',
                 '--get-request': False,
                 '--datastore-fields': False,
+                '--insecure': False
             },
             worker_pool=self._mock_worker_pool,
             stdout=self.stdout,
@@ -184,6 +191,7 @@ class TestCLIDump(unittest.TestCase):
                 '--processes': '1',
                 '--get-request': False,
                 '--datastore-fields': False,
+                '--insecure': False
             },
 
             worker_pool=self._mock_worker_pool,
@@ -212,6 +220,7 @@ class TestCLIDump(unittest.TestCase):
                 '--processes': '1',
                 '--get-request': False,
                 '--datastore-fields': False,
+                '--insecure': False
             },
             worker_pool=self._mock_worker_pool_reversed,
             stdout=self.stdout,
@@ -244,6 +253,7 @@ class TestCLIDump(unittest.TestCase):
                     '--processes': '1',
                     '--get-request': False,
                     '--datastore-fields': False,
+                    '--insecure': False
                 },
                 worker_pool=self._worker_pool_with_data,
                 stdout=self.stdout,
@@ -293,7 +303,8 @@ class TestCLIDump(unittest.TestCase):
         worker_stdin = BytesIO(b''.join(v for i, v in job_iter))
         worker_stdout = BytesIO()
         dump_things_worker(self.ckan, 'datasets', {
-            '--datastore-fields': True},
+            '--datastore-fields': True,
+            '--insecure': False},
             stdin=worker_stdin,
             stdout=worker_stdout)
         for i, v in enumerate(worker_stdout.getvalue().strip().split(b'\n')):

--- a/ckanapi/tests/test_cli_load.py
+++ b/ckanapi/tests/test_cli_load.py
@@ -9,7 +9,7 @@ except ImportError:
 from io import BytesIO
 
 class MockCKAN(object):
-    def call_action(self, name, data_dict):
+    def call_action(self, name, data_dict, requests_kwargs=None):
         if name == 'package_show' and data_dict['id'] == 'seekrit':
             raise NotAuthorized('naughty user')
         if name == 'package_create' and data_dict.get('name') == '34':
@@ -67,7 +67,8 @@ class TestCLILoad(unittest.TestCase):
         load_things_worker(self.ckan, 'datasets', {
                 '--create-only': False,
                 '--update-only': False,
-                '--upload-resources':False,
+                '--upload-resources': False,
+                '--insecure': False
                 },
             stdin=BytesIO(b'{"name": "45","title":"Forty-five"}\n'),
             stdout=self.stdout)
@@ -82,7 +83,8 @@ class TestCLILoad(unittest.TestCase):
         load_things_worker(self.ckan, 'datasets', {
                 '--create-only': False,
                 '--update-only': False,
-                '--upload-resources':False,
+                '--upload-resources': False,
+                '--insecure': False
                 },
             stdin=BytesIO(b'{"name": "45","title":"Forty-five","resources":[{"id":"123"}]}\n'),
             stdout=self.stdout)
@@ -97,7 +99,8 @@ class TestCLILoad(unittest.TestCase):
         load_things_worker(self.ckan, 'datasets', {
                 '--create-only': False,
                 '--update-only': False,
-                '--upload-resources':False,
+                '--upload-resources': False,
+                '--insecure': False
                 },
             stdin=BytesIO(
                  b'{"name": "45","title":"Forty-five",'
@@ -114,7 +117,8 @@ class TestCLILoad(unittest.TestCase):
         load_things_worker(self.ckan, 'datasets', {
                 '--create-only': True,
                 '--update-only': False,
-                '--upload-resources':False,
+                '--upload-resources': False,
+                '--insecure': False
                 },
             stdin=BytesIO(b'{"name": "45","title":"Forty-five"}\n'),
             stdout=self.stdout)
@@ -129,7 +133,8 @@ class TestCLILoad(unittest.TestCase):
         load_things_worker(self.ckan, 'datasets', {
                 '--create-only': False,
                 '--update-only': False,
-                '--upload-resources':False,
+                '--upload-resources': False,
+                '--insecure': False
                 },
             stdin=BytesIO(b'{}\n'),
             stdout=self.stdout)
@@ -144,6 +149,7 @@ class TestCLILoad(unittest.TestCase):
         load_things_worker(self.ckan, 'datasets', {
                 '--create-only': False,
                 '--update-only': True,
+                '--insecure': False
                 },
             stdin=BytesIO(b'{"name": "45","title":"Forty-five"}\n'),
             stdout=self.stdout)
@@ -158,6 +164,7 @@ class TestCLILoad(unittest.TestCase):
         load_things_worker(self.ckan, 'datasets', {
                 '--create-only': False,
                 '--update-only': False,
+                '--insecure': False
                 },
             stdin=BytesIO(b'{"name": "30ish","title":"3.4 times ten"}\n'),
             stdout=self.stdout)
@@ -173,6 +180,7 @@ class TestCLILoad(unittest.TestCase):
                 '--create-only': False,
                 '--update-only': False,
                 '--upload-resources': False,
+                '--insecure': False
                 },
             stdin=BytesIO(b'{"name": "30ish","title":"3.4 times ten","resources":[{"id":"123"}]}\n'),
             stdout=self.stdout)
@@ -188,6 +196,7 @@ class TestCLILoad(unittest.TestCase):
                 '--create-only': False,
                 '--update-only': False,
                 '--upload-resources': False,
+                '--insecure': False
                 },
             stdin=BytesIO(
                  b'{"name": "30ish","title":"3.4 times ten",'
@@ -205,6 +214,7 @@ class TestCLILoad(unittest.TestCase):
                 '--create-only': False,
                 '--update-only': True,
                 '--upload-resources': False,
+                '--insecure': False
                 },
             stdin=BytesIO(b'{"name": "34","title":"3.4 times ten"}\n'),
             stdout=self.stdout)
@@ -220,6 +230,7 @@ class TestCLILoad(unittest.TestCase):
                 '--create-only': True,
                 '--update-only': False,
                 '--upload-resources': False,
+                '--insecure': False
                 },
             stdin=BytesIO(b'{"name": "34","title":"3.4 times ten"}\n'),
             stdout=self.stdout)
@@ -235,6 +246,7 @@ class TestCLILoad(unittest.TestCase):
                 '--create-only': False,
                 '--update-only': False,
                 '--upload-resources': False,
+                '--insecure': False
                 },
             stdin=BytesIO(b'{"name": "seekrit", "title": "Things"}\n'),
             stdout=self.stdout)
@@ -250,6 +262,7 @@ class TestCLILoad(unittest.TestCase):
                 '--create-only': False,
                 '--update-only': False,
                 '--upload-resources': False,
+                '--insecure': False
                 },
             stdin=BytesIO(b'{"id": "ab","title":"a balloon"}\n'),
             stdout=self.stdout)
@@ -265,6 +278,7 @@ class TestCLILoad(unittest.TestCase):
                 '--create-only': False,
                 '--update-only': False,
                 '--upload-resources': False,
+                '--insecure': False
                 },
             stdin=BytesIO(
                 b'{"name": "cd", "title": "Go"}\n'
@@ -288,6 +302,7 @@ class TestCLILoad(unittest.TestCase):
                 '--create-only': False,
                 '--update-only': False,
                 '--upload-resources': False,
+                '--insecure': False
                 },
             stdin=BytesIO(b'{"id": "used", "title": "here"}\n'),
             stdout=self.stdout)
@@ -303,6 +318,7 @@ class TestCLILoad(unittest.TestCase):
                 '--create-only': False,
                 '--update-only': False,
                 '--upload-resources': False,
+                '--insecure': False
                 },
             stdin=BytesIO(b'{"id": "unused", "users": []}\n'),
             stdout=self.stdout)
@@ -330,7 +346,8 @@ class TestCLILoad(unittest.TestCase):
                 '--start-record': '1',
                 '--max-records': None,
                 '--upload-resources': False,
-                '--upload-logo':False
+                '--upload-logo': False,
+                '--insecure': False
             },
             worker_pool=self._mock_worker_pool,
             stdin=BytesIO(
@@ -364,7 +381,8 @@ class TestCLILoad(unittest.TestCase):
                 '--start-record': '2',
                 '--max-records': '2',
                 '--upload-resources': False,
-                '--upload-logo':False,
+                '--upload-logo': False,
+                '--insecure': False
             },
             worker_pool=self._mock_worker_pool,
             stdin=BytesIO(
@@ -401,7 +419,8 @@ class TestCLILoad(unittest.TestCase):
                 '--start-record': '1',
                 '--max-records': None,
                 '--upload-resources': False,
-                '--upload-logo':False,
+                '--upload-logo': False,
+                '--insecure': False
             },
             worker_pool=self._mock_worker_pool,
             stdin=BytesIO(


### PR DESCRIPTION
This PR addresses an issue in the CLI where ssl certificates cannot be verified by the requests library and raises an sslError: `raise SSLError(e, request=request)`

This general issue is addressed in #51 where @wardi points out that you can bypass this error using:

> https://github.com/ckan/ckanapi/blob/master/ckanapi/remoteckan.py#L53 with requests_kwargs={'verify': False}

Here I've added the `--no-verify` option to the `ckanapi action` command line interface which will allow users to work around this issue. Obviously, user be warned not to trust passing their API key around like this =)

Here is an example:
```
ckanapi action -r https://catalog.data.gov package_show id=demographic-statistics-by-zip-code-acfc9 --no-verify
```
Let me know if this works or if there is a better approach!