### PR TITLE
Update TestApp.post signature

### DIFF
--- a/ckanapi/testappckan.py
+++ b/ckanapi/testappckan.py
@@ -51,6 +51,6 @@ class TestAppCKAN(object):
                 upload_files.append( (fieldname, filename, file_.read()) )
             kwargs['upload_files'] = upload_files
 
-        r = self.test_app.post('/' + url, data, headers, expect_errors=True,
-                               **kwargs)
+        r = self.test_app.post('/' + url, params=data, headers=headers,
+                               expect_errors=True, **kwargs)
         return reverse_apicontroller_action(url, r.status, r.body)


### PR DESCRIPTION
Right now `ckanapi.TestAppCKAN` raising an exception [in this line](https://github.com/ckan/ckanapi/blob/master/ckanapi/testappckan.py#L54). In new test client, signature of `post` method is `url, base_url, query_params`. Using explicit names will solve the problem because new test client adapts named arguments (unlike the positioned ones)