### PR TITLE
Fix error class import fail due to local directory named 'ckan'.

### DIFF
--- a/ckanapi/errors.py
+++ b/ckanapi/errors.py
@@ -28,7 +28,9 @@ class CLIError(Exception):
 
 
 try:
-    import ckan
+    from ckan.logic import (NotAuthorized, NotFound, ValidationError)
+    from ckan.lib.search import (SearchQueryError, SearchError,
+                                 SearchIndexError)
 
 except ImportError:
     # Implement the minimum to be compatible with existing errors
@@ -57,10 +59,4 @@ except ImportError:
 
     class SearchIndexError(CKANAPIError):
         pass
-
-else:
-    # import ckan worked, so these must not fail
-    from ckan.logic import (NotAuthorized, NotFound, ValidationError)
-    from ckan.lib.search import (SearchQueryError, SearchError,
-                                 SearchIndexError)
 


### PR DESCRIPTION
##  Overview
I have encountered this bug while developing a helper script next to my docker-compose configuration for CKAN stack. Next to the script I have a `ckan` directory with a Dockerfile and image related stuff.
I'm not sure if it's a proper fix for this, but earlier behaviour depending on fallback on `import ckan` looked weak to me. I think we should generate error classes stubs only after actual classes we need fail to import.

## Minimal steps to reproduce the issue:
1. create a script `main.py` with the following content:
```
# main.py
import ckanapi

if __name__ == '__main__':
    print("Works.")
```
2. Running the script with `python3 main.py` works fine.
3. Create an empty directory ckan
```
mkdir ckan
```
project directory tree:
```
.
├── ckan # empty directory
└── main.py
```
4. Running the script errors with:
```
$ python3 main.py
Traceback (most recent call last):
  File "main.py", line 1, in <module>
    import ckanapi
  File "/home/tomek/tmp/venv/local/lib/python3.6/site-packages/ckanapi/__init__.py", line 8, in <module>
    from ckanapi.errors import (
  File "/home/tomek/tmp/venv/local/lib/python3.6/site-packages/ckanapi/errors.py", line 63, in <module>
    from ckan.logic import (NotAuthorized, NotFound, ValidationError)
ModuleNotFoundError: No module named 'ckan.logic'
```
because python import the local directory ckan as a package and it causes the error stubs generation in `ckanapi.errors` to fail.

