### PR TITLE
switch to simplejson

### DIFF
--- a/ckanapi/common.py
+++ b/ckanapi/common.py
@@ -2,7 +2,7 @@
 Code shared by LocalCKAN, RemoteCKAN and TestCKAN
 """
 
-import json
+import simplejson as json
 
 from ckanapi.errors import (CKANAPIError, NotAuthorized, NotFound,
     ValidationError, SearchQueryError, SearchError, SearchIndexError,


### PR DESCRIPTION
Simplejson 2.1 and higher has native support for encoding data of Decimal type which is useful for Datastore API actions, in particular, uploading Decimal data using the 'datastore_create' API action. 