### PR TITLE
Environment variables for --config and --apikey

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,15 @@ $ ckanapi dump datasets --all -q -r http://sourceckan.example.com \
   | ckanapi load datasets
 ```
 
+### Environment variables
+You may also specify the `--config` and `--apikey` CLI arguments using the
+**CKAN_INI** and **CKANAPI_KEY** environment variables respectively.
+
+```
+export CKAN_INI=/etc/ckan/default/ckan.ini
+export CKANAPI_KEY=<YOUR CKAN API KEY>
+```
+
 
 ## ckanapi Python Module
 

--- a/README.md
+++ b/README.md
@@ -221,8 +221,8 @@ You may also specify the `--config` and `--apikey` CLI arguments using the
 **CKAN_INI** and **CKANAPI_KEY** environment variables respectively.
 
 ```
-export CKAN_INI=/etc/ckan/default/ckan.ini
-export CKANAPI_KEY=<YOUR CKAN API KEY>
+$ export CKAN_INI=/etc/ckan/default/ckan.ini
+$ export CKANAPI_KEY=<YOUR CKAN API KEY>
 ```
 
 

--- a/ckanapi/cli/main.py
+++ b/ckanapi/cli/main.py
@@ -93,10 +93,10 @@ from ckanapi.cli.search import search_datasets
 def parse_arguments():
     # docopt is awesome
     arguments = docopt(__doc__, version=__version__)
-    if not arguments['--config']:
+    if not arguments['--config'] and not arguments['--apikey']:
         arguments['--config'] = os.getenv('CKAN_INI', '')
-    if not arguments['--apikey']:
-        arguments['--apikey'] = os.getenv('CKANAPI_KEY', '')
+        if not arguments['--config']:
+            arguments['--apikey'] = os.getenv('CKANAPI_KEY', '')
     return arguments
 
 

--- a/ckanapi/cli/main.py
+++ b/ckanapi/cli/main.py
@@ -92,7 +92,12 @@ from ckanapi.cli.search import search_datasets
 
 def parse_arguments():
     # docopt is awesome
-    return docopt(__doc__, version=__version__)
+    arguments = docopt(__doc__, version=__version__)
+    if not arguments['--config']:
+        arguments['--config'] = os.getenv('CKAN_INI', '')
+    if not arguments['--apikey']:
+        arguments['--apikey'] = os.getenv('CKANAPI_KEY', '')
+    return arguments
 
 
 def main(running_with_paster=False):


### PR DESCRIPTION
Resolves #179.

Added `--apikey`  as well. Not only is it convenient at the CLI, its also good for securely passing secrets when containerizing.