### PR TITLE
Allow the base_url of 'action/api/' to be overriden via subclassing

### DIFF
--- a/ckanapi/common.py
+++ b/ckanapi/common.py
@@ -63,7 +63,7 @@ def is_file_like(v):
 
 
 def prepare_action(action, data_dict=None, apikey=None, files=None,
-                   base_url='action/api'):
+                   base_url='action/api/'):
     """
     Return action_url, data_json, http_headers
     """

--- a/ckanapi/common.py
+++ b/ckanapi/common.py
@@ -62,7 +62,8 @@ def is_file_like(v):
         isinstance(v, tuple) and len(v) >= 2 and hasattr(v[1], 'read'))
 
 
-def prepare_action(action, data_dict=None, apikey=None, files=None):
+def prepare_action(action, data_dict=None, apikey=None, files=None,
+                   base_url='action/api'):
     """
     Return action_url, data_json, http_headers
     """
@@ -87,7 +88,7 @@ def prepare_action(action, data_dict=None, apikey=None, files=None):
         apikey = str(apikey)
         headers['X-CKAN-API-Key'] = apikey
         headers['Authorization'] = apikey
-    url = 'api/action/' + action
+    url = base_url + action
     return url, data_dict, headers
 
 

--- a/ckanapi/remoteckan.py
+++ b/ckanapi/remoteckan.py
@@ -36,6 +36,9 @@ class RemoteCKAN(object):
     :param get_only: only use GET requests (default: False)
     :param session: session to use (default: None)
     """
+
+    base_url = 'api/action'
+
     def __init__(self, address, apikey=None, user_agent=None, get_only=False, session=None):
         self.address = address
         self.apikey = apikey
@@ -80,7 +83,8 @@ class RemoteCKAN(object):
             raise CKANAPIError("RemoteCKAN: files may not be sent when "
                 "get_only is True")
         url, data, headers = prepare_action(
-            action, data_dict, apikey or self.apikey, files)
+            action, data_dict, apikey or self.apikey, files,
+            base_url=self.base_url)
         headers['User-Agent'] = self.user_agent
         url = self.address.rstrip('/') + '/' + url
         requests_kwargs = requests_kwargs or {}

--- a/ckanapi/remoteckan.py
+++ b/ckanapi/remoteckan.py
@@ -37,7 +37,7 @@ class RemoteCKAN(object):
     :param session: session to use (default: None)
     """
 
-    base_url = 'api/action'
+    base_url = 'api/action/'
 
     def __init__(self, address, apikey=None, user_agent=None, get_only=False, session=None):
         self.address = address


### PR DESCRIPTION
Following on from https://github.com/ckan/ckanapi/pull/149 and achieving the same result using the suggested approach (I have a need for the same functionality).