### PR TITLE
Added option for dumping resource views into the resource dicts durin…

### DIFF
--- a/ckanapi/cli/dump.py
+++ b/ckanapi/cli/dump.py
@@ -14,7 +14,8 @@ from ckanapi.cli import workers
 from ckanapi.cli.utils import completion_stats, compact_json, \
     quiet_int_pipe
 from ckanapi.datapackage import create_datapackage, \
-    populate_datastore_res_fields
+    populate_datastore_res_fields, \
+    populate_datastore_res_views
 
 
 def dump_things(ckan, thing, arguments,
@@ -185,6 +186,9 @@ def dump_things_worker(ckan, thing, arguments,
             if thing == 'datasets' and arguments['--datastore-fields']:
                 for res in obj.get('resources', []):
                     populate_datastore_res_fields(ckan, res)
+            if thing == 'datasets' and arguments['--resource-views']:
+                for res in obj.get('resources', []):
+                    populate_datastore_res_views(ckan, res)
             reply(None, obj)
 
 def _worker_command_line(thing, arguments):
@@ -206,5 +210,6 @@ def _worker_command_line(thing, arguments):
         + a('--apikey')
         + b('--get-request')
         + b('--datastore-fields')
+        + b('--resource-views')
         + ['value-here-to-make-docopt-happy']
         )

--- a/ckanapi/cli/dump.py
+++ b/ckanapi/cli/dump.py
@@ -8,14 +8,13 @@ import json
 from datetime import datetime
 import os
 
-from ckanapi.errors import (NotFound, NotAuthorized, ValidationError,
+from ckanapi.errors import (CKANAPIError, NotFound, NotAuthorized, ValidationError,
     SearchIndexError)
 from ckanapi.cli import workers
 from ckanapi.cli.utils import completion_stats, compact_json, \
     quiet_int_pipe
 from ckanapi.datapackage import create_datapackage, \
-    populate_datastore_res_fields, \
-    populate_datastore_res_views
+    populate_datastore_res_fields
 
 
 def dump_things(ckan, thing, arguments,
@@ -213,3 +212,25 @@ def _worker_command_line(thing, arguments):
         + b('--resource-views')
         + ['value-here-to-make-docopt-happy']
         )
+
+
+def populate_datastore_res_views(ckan, res):
+    """
+    update resource dict in-place with resource_view_list values
+    in every resource with datastore active using ckan
+    LocalCKAN/RemoteCKAN instance
+    """
+    if not res.get('datastore_active', False):
+        return
+    try:
+        ds = ckan.call_action('resource_view_list', {
+            'id': res['id'],
+            'limit':0})
+    except CKANAPIError:
+        return
+    except NotFound:
+        return  # with localckan we'll get the real CKAN exception not a CKANAPIError subclass
+    if not ds:
+        return # return if the resource views list is empty
+    res['resource_views'] = ds
+

--- a/ckanapi/cli/main.py
+++ b/ckanapi/cli/main.py
@@ -14,7 +14,7 @@ Usage:
           [[-c CONFIG] [-u USER] | -r SITE_URL [-a APIKEY] [--insecure]]
   ckanapi dump (datasets | groups | organizations | users | related)
           (ID_OR_NAME ... | --all) ([-O JSONL_OUTPUT] | [-D DIRECTORY])
-          [-p PROCESSES] [-dqwz]
+          [-p PROCESSES] [-dqwzR]
           [[-c CONFIG] [-u USER] | -r SITE_URL [-a APIKEY] [-g] [--insecure]]
   ckanapi load datasets
           [--upload-resources] [-I JSONL_INPUT] [-s START] [-m MAX]
@@ -64,6 +64,8 @@ Options:
   -p --processes=PROCESSES  set the number of worker processes [default: 1]
   -q --quiet                don't display progress messages
   -r --remote=URL           URL of CKAN server for remote actions
+  -R --resource-views       export resource views information along with
+                            resource metadata as resource_views lists
   -s --start-record=START   start from record number START, where the first
                             record is number 1 [default: 1]
   -u --ckan-user=USER       perform actions as user with this name, uses the

--- a/ckanapi/datapackage.py
+++ b/ckanapi/datapackage.py
@@ -137,6 +137,25 @@ def populate_datastore_res_fields(ckan, res):
         return  # with localckan we'll get the real CKAN exception not a CKANAPIError subclass
     res['datastore_fields'] = ds['fields']
 
+def populate_datastore_res_views(ckan, res):
+    """
+    update resource dict in-place with resource_view_list values
+    in every resource with datastore active using ckan
+    LocalCKAN/RemoteCKAN instance
+    """
+    if not res.get('datastore_active', False):
+        return
+    try:
+        ds = ckan.call_action('resource_view_list', {
+            'id': res['id'],
+            'limit':0})
+    except CKANAPIError:
+        return
+    except NotFound:
+        return  # with localckan we'll get the real CKAN exception not a CKANAPIError subclass
+    if not ds:
+        return # return if the resource views list is empty
+    res['resource_views'] = ds
 
 # functions below are from https://github.com/frictionlessdata/ckan-datapackage-tools
 # commit c87e07d0d0

--- a/ckanapi/datapackage.py
+++ b/ckanapi/datapackage.py
@@ -137,25 +137,6 @@ def populate_datastore_res_fields(ckan, res):
         return  # with localckan we'll get the real CKAN exception not a CKANAPIError subclass
     res['datastore_fields'] = ds['fields']
 
-def populate_datastore_res_views(ckan, res):
-    """
-    update resource dict in-place with resource_view_list values
-    in every resource with datastore active using ckan
-    LocalCKAN/RemoteCKAN instance
-    """
-    if not res.get('datastore_active', False):
-        return
-    try:
-        ds = ckan.call_action('resource_view_list', {
-            'id': res['id'],
-            'limit':0})
-    except CKANAPIError:
-        return
-    except NotFound:
-        return  # with localckan we'll get the real CKAN exception not a CKANAPIError subclass
-    if not ds:
-        return # return if the resource views list is empty
-    res['resource_views'] = ds
 
 # functions below are from https://github.com/frictionlessdata/ckan-datapackage-tools
 # commit c87e07d0d0

--- a/ckanapi/tests/test_cli_dump.py
+++ b/ckanapi/tests/test_cli_dump.py
@@ -50,6 +50,15 @@ class MockCKAN(object):
                                 'label': 'Column One',
                                 'notes': 'Description One',
                             }}]}},
+                'resource_view_list': {
+                    'd902fafc-5717-4dd0-87f2-7a6fc96989b7': [{
+                            'description': 'Test view',
+                            'filterable': True,
+                            'id': 'd902fafc-5717-4dd0-87f2-7a6fc96989d9',
+                            'package_id': 'dp',
+                            'resource_id': 'd902fafc-5717-4dd0-87f2-7a6fc96989b7',
+                            'responsive': True,
+                            'show_fields': ['_id']}]},
             }[name][data_dict.get('id') or data_dict.get('resource_id')]
         except KeyError:
             raise NotFound()
@@ -292,6 +301,59 @@ class TestCLIDump(unittest.TestCase):
         finally:
             shutil.rmtree(target)
 
+    
+    def test_resource_views(self):
+        target = tempfile.mkdtemp()
+        try:
+            dump_things(self.ckan, 'datasets', {
+                    'ID_OR_NAME': ['dp'],
+                    '--quiet': False,
+                    '--ckan-user': None,
+                    '--config': None,
+                    '--remote': None,
+                    '--apikey': None,
+                    '--worker': False,
+                    '--log': None,
+                    '--output': target + '/dpf.jsonl',
+                    '--datapackages': None,
+                    '--gzip': False,
+                    '--all': False,
+                    '--processes': '1',
+                    '--get-request': False,
+                    '--datastore-fields': False,
+                    '--resource-views': True,
+                    '--insecure': False
+                },
+                worker_pool=self._worker_pool_with_resource_views,
+                stdout=self.stdout,
+                stderr=self.stderr)
+            assert exists(target + '/dpf.jsonl')
+            with open(target + '/dpf.jsonl') as dpf:
+                dp = json.load(dpf)
+            self.assertEqual(dp, {
+                'id': 'dp',
+                'name': 'dp',
+                'title': 'Test for datapackage',
+                'resources': [{
+                    'name': 'resource1',
+                    'format': 'csv',
+                    'id': 'd902fafc-5717-4dd0-87f2-7a6fc96989b7',
+                    'url': 'https://google.com',
+                    'datastore_active': True,
+                    'resource_views': [{
+                        'description': 'Test view',
+                        'filterable': True,
+                        'id': 'd902fafc-5717-4dd0-87f2-7a6fc96989d9',
+                        'package_id': 'dp',
+                        'resource_id': 'd902fafc-5717-4dd0-87f2-7a6fc96989b7',
+                        'responsive': True,
+                        'show_fields': ['_id']
+                    }]
+                }]
+            })
+        finally:
+            shutil.rmtree(target)
+
 
     def _mock_worker_pool(self, cmd, processes, job_iter):
         self.worker_cmd = cmd
@@ -311,6 +373,19 @@ class TestCLIDump(unittest.TestCase):
         worker_stdout = BytesIO()
         dump_things_worker(self.ckan, 'datasets', {
             '--datastore-fields': True,
+            '--resource-views': False,
+            '--insecure': False},
+            stdin=worker_stdin,
+            stdout=worker_stdout)
+        for i, v in enumerate(worker_stdout.getvalue().strip().split(b'\n')):
+            yield [[], i, v]
+
+    
+    def _worker_pool_with_resource_views(self, cmd, proccesses, job_iter):
+        worker_stdin = BytesIO(b''.join(v for i, v in job_iter))
+        worker_stdout = BytesIO()
+        dump_things_worker(self.ckan, 'datasets', {
+            '--datastore-fields': False,
             '--resource-views': True,
             '--insecure': False},
             stdin=worker_stdin,

--- a/ckanapi/tests/test_cli_dump.py
+++ b/ckanapi/tests/test_cli_dump.py
@@ -64,6 +64,7 @@ class TestCLIDump(unittest.TestCase):
     def test_worker_one(self):
         rval = dump_things_worker(self.ckan, 'datasets',
             {'--datastore-fields': False,
+             '--resource-views': False,
              '--insecure': False},
             stdin=BytesIO(b'"34"\n'), stdout=self.stdout)
         response = self.stdout.getvalue()
@@ -75,6 +76,7 @@ class TestCLIDump(unittest.TestCase):
     def test_worker_two(self):
         rval = dump_things_worker(self.ckan, 'datasets',
             {'--datastore-fields': False,
+             '--resource-views': False,
              '--insecure': False},
             stdin=BytesIO(b'"12"\n"34"\n'), stdout=self.stdout)
         response = self.stdout.getvalue()
@@ -134,6 +136,7 @@ class TestCLIDump(unittest.TestCase):
                 '--processes': '1',
                 '--get-request': False,
                 '--datastore-fields': False,
+                '--resource-views': False,
                 '--insecure': False
             },
             worker_pool=self._mock_worker_pool,
@@ -164,6 +167,7 @@ class TestCLIDump(unittest.TestCase):
                 '--processes': '5',
                 '--get-request': False,
                 '--datastore-fields': False,
+                '--resource-views': False,
                 '--insecure': False
             },
             worker_pool=self._mock_worker_pool,
@@ -191,6 +195,7 @@ class TestCLIDump(unittest.TestCase):
                 '--processes': '1',
                 '--get-request': False,
                 '--datastore-fields': False,
+                '--resource-views': False,
                 '--insecure': False
             },
 
@@ -220,6 +225,7 @@ class TestCLIDump(unittest.TestCase):
                 '--processes': '1',
                 '--get-request': False,
                 '--datastore-fields': False,
+                '--resource-views': False,
                 '--insecure': False
             },
             worker_pool=self._mock_worker_pool_reversed,
@@ -253,6 +259,7 @@ class TestCLIDump(unittest.TestCase):
                     '--processes': '1',
                     '--get-request': False,
                     '--datastore-fields': False,
+                    '--resource-views': False,
                     '--insecure': False
                 },
                 worker_pool=self._worker_pool_with_data,
@@ -304,6 +311,7 @@ class TestCLIDump(unittest.TestCase):
         worker_stdout = BytesIO()
         dump_things_worker(self.ckan, 'datasets', {
             '--datastore-fields': True,
+            '--resource-views': True,
             '--insecure': False},
             stdin=worker_stdin,
             stdout=worker_stdout)


### PR DESCRIPTION
…g dataset dumps.

Added --resource-views (-R) flag to the dump datasets api action. The boolean flag allows for the resource views lists to be added into the resource dicts as the index "resource_views".

If there are no views for a resource, it will NOT add the "resource_views" index to the resource dicts.

Also added the new flag to the pytests.