### PR TITLE
Fix API URL inside TestClient

### DIFF
--- a/ckanapi/common.py
+++ b/ckanapi/common.py
@@ -63,7 +63,7 @@ def is_file_like(v):
 
 
 def prepare_action(action, data_dict=None, apikey=None, files=None,
-                   base_url='action/api/'):
+                   base_url='api/action/'):
     """
     Return action_url, data_json, http_headers
     """


### PR DESCRIPTION
Looks like there was a typo at some point. Now API URLs inside the test client are invalid: `/action/api/<action>` (first segment is `action`) instead of `/api/action/<action>` (first segment is `api`)