### PR TITLE
Argument to Inlude Group/Org Users in Dump and Load (+ fixed tests)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,7 @@ jobs:
     strategy:
       matrix:
         python-version: ["2.7", "3.8"]
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ jobs:
   test:
     strategy:
       matrix:
-        python-version: ["2.7", "3.8"]
+        python-version: ["3.8"]
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,7 +5,11 @@ jobs:
     strategy:
       matrix:
         python-version: ["2.7", "3.8"]
-    runs-on: python:${{ matrix.python-version }}
+    runs-on: ubuntu-latest
+    container:
+      # INFO: python 2 is no longer supported in
+      # actions/setup-python, use python docker image instead
+      image: python:${{ matrix.python-version }}
 
     steps:
     - uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,17 +4,13 @@ jobs:
   test:
     strategy:
       matrix:
-        python-version: ["3.8"]
-    runs-on: ubuntu-latest
+        python-version: ["2.7", "3.8"]
+    runs-on: python:${{ matrix.python-version }}
 
     steps:
     - uses: actions/checkout@v3
-    - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v4
-      with:
-        python-version: ${{ matrix.python-version }}
-    - name: Install requirements
+    - name: Install requirements (py ${{ matrix.python-version }})
       run: |
         pip install -e ".[testing]"
-    - name: Run all tests
+    - name: Run all tests (py ${{ matrix.python-version }})
       run: python -m unittest discover

--- a/ckanapi/cli/dump.py
+++ b/ckanapi/cli/dump.py
@@ -173,9 +173,13 @@ def dump_things_worker(ckan, thing, arguments,
             requests_kwargs = None
             if arguments['--insecure']:
                 requests_kwargs = {'verify': False}
+            include_users = False
+            if arguments['--include-users']:
+                include_users = True
             obj = ckan.call_action(thing_show, {'id': name,
                 'include_datasets': False,
                 'include_password_hash': True,
+                'include_users': include_users,
                 }, requests_kwargs=requests_kwargs)
         except NotFound:
             reply('NotFound')
@@ -210,6 +214,7 @@ def _worker_command_line(thing, arguments):
         + b('--get-request')
         + b('--datastore-fields')
         + b('--resource-views')
+        + b('--include-users')
         + ['value-here-to-make-docopt-happy']
         )
 

--- a/ckanapi/cli/dump.py
+++ b/ckanapi/cli/dump.py
@@ -118,9 +118,15 @@ def dump_things(ckan, thing, arguments,
                         sort_keys=True) + b'\n')
                 expecting_number += 1
     if 'pipe' in errors:
+        if jsonl_output != stdout:
+            jsonl_output.close()
         return 1
     if 'interrupt' in errors:
+        if jsonl_output != stdout:
+            jsonl_output.close()
         return 2
+    if jsonl_output != stdout:
+        jsonl_output.close()
 
 
 def dump_things_worker(ckan, thing, arguments,

--- a/ckanapi/cli/dump.py
+++ b/ckanapi/cli/dump.py
@@ -117,16 +117,12 @@ def dump_things(ckan, thing, arguments,
                     jsonl_output.write(compact_json(record,
                         sort_keys=True) + b'\n')
                 expecting_number += 1
-    if 'pipe' in errors:
-        if jsonl_output != stdout:
-            jsonl_output.close()
-        return 1
-    if 'interrupt' in errors:
-        if jsonl_output != stdout:
-            jsonl_output.close()
-        return 2
     if jsonl_output != stdout:
         jsonl_output.close()
+    if 'pipe' in errors:
+        return 1
+    if 'interrupt' in errors:
+        return 2
 
 
 def dump_things_worker(ckan, thing, arguments,

--- a/ckanapi/cli/dump.py
+++ b/ckanapi/cli/dump.py
@@ -174,7 +174,8 @@ def dump_things_worker(ckan, thing, arguments,
             if arguments['--insecure']:
                 requests_kwargs = {'verify': False}
             include_users = False
-            if arguments['--include-users']:
+            if '--include-users' in arguments \
+            and arguments['--include-users']:
                 include_users = True
             obj = ckan.call_action(thing_show, {'id': name,
                 'include_datasets': False,

--- a/ckanapi/cli/load.py
+++ b/ckanapi/cli/load.py
@@ -174,6 +174,10 @@ def load_things_worker(ckan, thing, arguments,
         if arguments['--insecure']:
             requests_kwargs = {'verify': False}
 
+        include_users = False
+        if arguments['--include-users']:
+            include_users = True
+
         if obj is not None:
             existing = None
             if not arguments['--create-only']:
@@ -185,6 +189,7 @@ def load_things_worker(ckan, thing, arguments,
                             {'id': name,
                              'include_datasets': False,
                              'include_password_hash': True,
+                             'include_users': include_users,
                             },
                             requests_kwargs=requests_kwargs)
                     except NotFound:
@@ -261,6 +266,7 @@ def _worker_command_line(thing, arguments):
         + b('--update-only')
         + b('--upload-resources')
         + b('--upload-logo')
+        + b('--include-users')
         )
 
 

--- a/ckanapi/cli/load.py
+++ b/ckanapi/cli/load.py
@@ -175,7 +175,8 @@ def load_things_worker(ckan, thing, arguments,
             requests_kwargs = {'verify': False}
 
         include_users = False
-        if arguments['--include-users']:
+        if '--include-users' in arguments \
+        and arguments['--include-users']:
             include_users = True
 
         if obj is not None:

--- a/ckanapi/cli/load.py
+++ b/ckanapi/cli/load.py
@@ -174,11 +174,6 @@ def load_things_worker(ckan, thing, arguments,
         if arguments['--insecure']:
             requests_kwargs = {'verify': False}
 
-        include_users = False
-        if '--include-users' in arguments \
-        and arguments['--include-users']:
-            include_users = True
-
         if obj is not None:
             existing = None
             if not arguments['--create-only']:
@@ -190,7 +185,7 @@ def load_things_worker(ckan, thing, arguments,
                             {'id': name,
                              'include_datasets': False,
                              'include_password_hash': True,
-                             'include_users': include_users,
+                             'include_users': True,
                             },
                             requests_kwargs=requests_kwargs)
                     except NotFound:
@@ -267,7 +262,6 @@ def _worker_command_line(thing, arguments):
         + b('--update-only')
         + b('--upload-resources')
         + b('--upload-logo')
-        + b('--include-users')
         )
 
 

--- a/ckanapi/cli/main.py
+++ b/ckanapi/cli/main.py
@@ -14,7 +14,7 @@ Usage:
           [[-c CONFIG] [-u USER] | -r SITE_URL [-a APIKEY] [--insecure]]
   ckanapi dump (datasets | groups | organizations | users | related)
           (ID_OR_NAME ... | --all) ([-O JSONL_OUTPUT] | [-D DIRECTORY])
-          [-p PROCESSES] [-dqwzR]
+          [-p PROCESSES] [-dqwzRU]
           [[-c CONFIG] [-u USER] | -r SITE_URL [-a APIKEY] [-g] [--insecure]]
   ckanapi load datasets
           [--upload-resources] [-I JSONL_INPUT] [-s START] [-m MAX]
@@ -22,7 +22,7 @@ Usage:
           [[-c CONFIG] [-u USER] | -r SITE_URL [-a APIKEY] [--insecure]]
   ckanapi load (groups | organizations)
           [--upload-logo] [-I JSONL_INPUT] [-s START] [-m MAX]
-          [-p PROCESSES] [-l LOG_FILE] [-n | -o] [-qwz]
+          [-p PROCESSES] [-l LOG_FILE] [-n | -o] [-qwzU]
           [[-c CONFIG] [-u USER] | -r SITE_URL [-a APIKEY] [--insecure]]
   ckanapi load (users | related)
           [-I JSONL_INPUT] [-s START] [-m MAX] [-p PROCESSES] [-l LOG_FILE]
@@ -70,6 +70,7 @@ Options:
                             record is number 1 [default: 1]
   -u --ckan-user=USER       perform actions as user with this name, uses the
                             site sysadmin user when not specified
+  -U --include-users        include users of a group/organization
   --upload-logo             upload logo image of a group/organization if the
                             image is stored in the original server, otherwise
                             its image url will be used

--- a/ckanapi/cli/search.py
+++ b/ckanapi/cli/search.py
@@ -79,3 +79,6 @@ def search_datasets(ckan, arguments, stdin=None, stdout=None, stderr=None):
             break
 
         start += len(rows)
+
+    if jsonl_output != stdout:
+        jsonl_output.close()

--- a/ckanapi/tests/test_cli_dump.py
+++ b/ckanapi/tests/test_cli_dump.py
@@ -146,7 +146,8 @@ class TestCLIDump(unittest.TestCase):
                 '--get-request': False,
                 '--datastore-fields': False,
                 '--resource-views': False,
-                '--insecure': False
+                '--insecure': False,
+                '--include-users': False,
             },
             worker_pool=self._mock_worker_pool,
             stdout=self.stdout,
@@ -177,7 +178,8 @@ class TestCLIDump(unittest.TestCase):
                 '--get-request': False,
                 '--datastore-fields': False,
                 '--resource-views': False,
-                '--insecure': False
+                '--insecure': False,
+                '--include-users': False,
             },
             worker_pool=self._mock_worker_pool,
             stdout=self.stdout,
@@ -205,7 +207,8 @@ class TestCLIDump(unittest.TestCase):
                 '--get-request': False,
                 '--datastore-fields': False,
                 '--resource-views': False,
-                '--insecure': False
+                '--insecure': False,
+                '--include-users': False,
             },
 
             worker_pool=self._mock_worker_pool,
@@ -235,7 +238,8 @@ class TestCLIDump(unittest.TestCase):
                 '--get-request': False,
                 '--datastore-fields': False,
                 '--resource-views': False,
-                '--insecure': False
+                '--insecure': False,
+                '--include-users': False,
             },
             worker_pool=self._mock_worker_pool_reversed,
             stdout=self.stdout,
@@ -269,7 +273,8 @@ class TestCLIDump(unittest.TestCase):
                     '--get-request': False,
                     '--datastore-fields': False,
                     '--resource-views': False,
-                    '--insecure': False
+                    '--insecure': False,
+                    '--include-users': False,
                 },
                 worker_pool=self._worker_pool_with_data,
                 stdout=self.stdout,
@@ -301,7 +306,7 @@ class TestCLIDump(unittest.TestCase):
         finally:
             shutil.rmtree(target)
 
-    
+
     def test_resource_views(self):
         target = tempfile.mkdtemp()
         try:
@@ -322,7 +327,8 @@ class TestCLIDump(unittest.TestCase):
                     '--get-request': False,
                     '--datastore-fields': False,
                     '--resource-views': True,
-                    '--insecure': False
+                    '--insecure': False,
+                    '--include-users': False,
                 },
                 worker_pool=self._worker_pool_with_resource_views,
                 stdout=self.stdout,
@@ -374,20 +380,22 @@ class TestCLIDump(unittest.TestCase):
         dump_things_worker(self.ckan, 'datasets', {
             '--datastore-fields': True,
             '--resource-views': False,
-            '--insecure': False},
+            '--insecure': False,
+            '--include-users': False,},
             stdin=worker_stdin,
             stdout=worker_stdout)
         for i, v in enumerate(worker_stdout.getvalue().strip().split(b'\n')):
             yield [[], i, v]
 
-    
+
     def _worker_pool_with_resource_views(self, cmd, proccesses, job_iter):
         worker_stdin = BytesIO(b''.join(v for i, v in job_iter))
         worker_stdout = BytesIO()
         dump_things_worker(self.ckan, 'datasets', {
             '--datastore-fields': False,
             '--resource-views': True,
-            '--insecure': False},
+            '--insecure': False,
+            '--include-users': False,},
             stdin=worker_stdin,
             stdout=worker_stdout)
         for i, v in enumerate(worker_stdout.getvalue().strip().split(b'\n')):

--- a/ckanapi/tests/test_cli_load.py
+++ b/ckanapi/tests/test_cli_load.py
@@ -68,7 +68,8 @@ class TestCLILoad(unittest.TestCase):
                 '--create-only': False,
                 '--update-only': False,
                 '--upload-resources': False,
-                '--insecure': False
+                '--insecure': False,
+                '--include-users': False,
                 },
             stdin=BytesIO(b'{"name": "45","title":"Forty-five"}\n'),
             stdout=self.stdout)
@@ -84,7 +85,8 @@ class TestCLILoad(unittest.TestCase):
                 '--create-only': False,
                 '--update-only': False,
                 '--upload-resources': False,
-                '--insecure': False
+                '--insecure': False,
+                '--include-users': False,
                 },
             stdin=BytesIO(b'{"name": "45","title":"Forty-five","resources":[{"id":"123"}]}\n'),
             stdout=self.stdout)
@@ -100,7 +102,8 @@ class TestCLILoad(unittest.TestCase):
                 '--create-only': False,
                 '--update-only': False,
                 '--upload-resources': False,
-                '--insecure': False
+                '--insecure': False,
+                '--include-users': False,
                 },
             stdin=BytesIO(
                  b'{"name": "45","title":"Forty-five",'
@@ -118,7 +121,8 @@ class TestCLILoad(unittest.TestCase):
                 '--create-only': True,
                 '--update-only': False,
                 '--upload-resources': False,
-                '--insecure': False
+                '--insecure': False,
+                '--include-users': False,
                 },
             stdin=BytesIO(b'{"name": "45","title":"Forty-five"}\n'),
             stdout=self.stdout)
@@ -134,7 +138,8 @@ class TestCLILoad(unittest.TestCase):
                 '--create-only': False,
                 '--update-only': False,
                 '--upload-resources': False,
-                '--insecure': False
+                '--insecure': False,
+                '--include-users': False,
                 },
             stdin=BytesIO(b'{}\n'),
             stdout=self.stdout)
@@ -149,7 +154,8 @@ class TestCLILoad(unittest.TestCase):
         load_things_worker(self.ckan, 'datasets', {
                 '--create-only': False,
                 '--update-only': True,
-                '--insecure': False
+                '--insecure': False,
+                '--include-users': False,
                 },
             stdin=BytesIO(b'{"name": "45","title":"Forty-five"}\n'),
             stdout=self.stdout)
@@ -164,7 +170,8 @@ class TestCLILoad(unittest.TestCase):
         load_things_worker(self.ckan, 'datasets', {
                 '--create-only': False,
                 '--update-only': False,
-                '--insecure': False
+                '--insecure': False,
+                '--include-users': False,
                 },
             stdin=BytesIO(b'{"name": "30ish","title":"3.4 times ten"}\n'),
             stdout=self.stdout)
@@ -180,7 +187,8 @@ class TestCLILoad(unittest.TestCase):
                 '--create-only': False,
                 '--update-only': False,
                 '--upload-resources': False,
-                '--insecure': False
+                '--insecure': False,
+                '--include-users': False,
                 },
             stdin=BytesIO(b'{"name": "30ish","title":"3.4 times ten","resources":[{"id":"123"}]}\n'),
             stdout=self.stdout)
@@ -196,7 +204,8 @@ class TestCLILoad(unittest.TestCase):
                 '--create-only': False,
                 '--update-only': False,
                 '--upload-resources': False,
-                '--insecure': False
+                '--insecure': False,
+                '--include-users': False,
                 },
             stdin=BytesIO(
                  b'{"name": "30ish","title":"3.4 times ten",'
@@ -214,7 +223,8 @@ class TestCLILoad(unittest.TestCase):
                 '--create-only': False,
                 '--update-only': True,
                 '--upload-resources': False,
-                '--insecure': False
+                '--insecure': False,
+                '--include-users': False,
                 },
             stdin=BytesIO(b'{"name": "34","title":"3.4 times ten"}\n'),
             stdout=self.stdout)
@@ -230,7 +240,8 @@ class TestCLILoad(unittest.TestCase):
                 '--create-only': True,
                 '--update-only': False,
                 '--upload-resources': False,
-                '--insecure': False
+                '--insecure': False,
+                '--include-users': False,
                 },
             stdin=BytesIO(b'{"name": "34","title":"3.4 times ten"}\n'),
             stdout=self.stdout)
@@ -246,7 +257,8 @@ class TestCLILoad(unittest.TestCase):
                 '--create-only': False,
                 '--update-only': False,
                 '--upload-resources': False,
-                '--insecure': False
+                '--insecure': False,
+                '--include-users': False,
                 },
             stdin=BytesIO(b'{"name": "seekrit", "title": "Things"}\n'),
             stdout=self.stdout)
@@ -262,7 +274,8 @@ class TestCLILoad(unittest.TestCase):
                 '--create-only': False,
                 '--update-only': False,
                 '--upload-resources': False,
-                '--insecure': False
+                '--insecure': False,
+                '--include-users': False,
                 },
             stdin=BytesIO(b'{"id": "ab","title":"a balloon"}\n'),
             stdout=self.stdout)
@@ -278,7 +291,8 @@ class TestCLILoad(unittest.TestCase):
                 '--create-only': False,
                 '--update-only': False,
                 '--upload-resources': False,
-                '--insecure': False
+                '--insecure': False,
+                '--include-users': False,
                 },
             stdin=BytesIO(
                 b'{"name": "cd", "title": "Go"}\n'
@@ -302,7 +316,8 @@ class TestCLILoad(unittest.TestCase):
                 '--create-only': False,
                 '--update-only': False,
                 '--upload-resources': False,
-                '--insecure': False
+                '--insecure': False,
+                '--include-users': False,
                 },
             stdin=BytesIO(b'{"id": "used", "title": "here"}\n'),
             stdout=self.stdout)
@@ -318,7 +333,8 @@ class TestCLILoad(unittest.TestCase):
                 '--create-only': False,
                 '--update-only': False,
                 '--upload-resources': False,
-                '--insecure': False
+                '--insecure': False,
+                '--include-users': False,
                 },
             stdin=BytesIO(b'{"id": "unused", "users": []}\n'),
             stdout=self.stdout)
@@ -347,7 +363,8 @@ class TestCLILoad(unittest.TestCase):
                 '--max-records': None,
                 '--upload-resources': False,
                 '--upload-logo': False,
-                '--insecure': False
+                '--insecure': False,
+                '--include-users': False,
             },
             worker_pool=self._mock_worker_pool,
             stdin=BytesIO(
@@ -382,7 +399,8 @@ class TestCLILoad(unittest.TestCase):
                 '--max-records': '2',
                 '--upload-resources': False,
                 '--upload-logo': False,
-                '--insecure': False
+                '--insecure': False,
+                '--include-users': False,
             },
             worker_pool=self._mock_worker_pool,
             stdin=BytesIO(
@@ -420,7 +438,8 @@ class TestCLILoad(unittest.TestCase):
                 '--max-records': None,
                 '--upload-resources': False,
                 '--upload-logo': False,
-                '--insecure': False
+                '--insecure': False,
+                '--include-users': False,
             },
             worker_pool=self._mock_worker_pool,
             stdin=BytesIO(

--- a/ckanapi/tests/test_cli_load.py
+++ b/ckanapi/tests/test_cli_load.py
@@ -69,7 +69,6 @@ class TestCLILoad(unittest.TestCase):
                 '--update-only': False,
                 '--upload-resources': False,
                 '--insecure': False,
-                '--include-users': False,
                 },
             stdin=BytesIO(b'{"name": "45","title":"Forty-five"}\n'),
             stdout=self.stdout)
@@ -86,7 +85,6 @@ class TestCLILoad(unittest.TestCase):
                 '--update-only': False,
                 '--upload-resources': False,
                 '--insecure': False,
-                '--include-users': False,
                 },
             stdin=BytesIO(b'{"name": "45","title":"Forty-five","resources":[{"id":"123"}]}\n'),
             stdout=self.stdout)
@@ -103,7 +101,6 @@ class TestCLILoad(unittest.TestCase):
                 '--update-only': False,
                 '--upload-resources': False,
                 '--insecure': False,
-                '--include-users': False,
                 },
             stdin=BytesIO(
                  b'{"name": "45","title":"Forty-five",'
@@ -122,7 +119,6 @@ class TestCLILoad(unittest.TestCase):
                 '--update-only': False,
                 '--upload-resources': False,
                 '--insecure': False,
-                '--include-users': False,
                 },
             stdin=BytesIO(b'{"name": "45","title":"Forty-five"}\n'),
             stdout=self.stdout)
@@ -139,7 +135,6 @@ class TestCLILoad(unittest.TestCase):
                 '--update-only': False,
                 '--upload-resources': False,
                 '--insecure': False,
-                '--include-users': False,
                 },
             stdin=BytesIO(b'{}\n'),
             stdout=self.stdout)
@@ -155,7 +150,6 @@ class TestCLILoad(unittest.TestCase):
                 '--create-only': False,
                 '--update-only': True,
                 '--insecure': False,
-                '--include-users': False,
                 },
             stdin=BytesIO(b'{"name": "45","title":"Forty-five"}\n'),
             stdout=self.stdout)
@@ -171,7 +165,6 @@ class TestCLILoad(unittest.TestCase):
                 '--create-only': False,
                 '--update-only': False,
                 '--insecure': False,
-                '--include-users': False,
                 },
             stdin=BytesIO(b'{"name": "30ish","title":"3.4 times ten"}\n'),
             stdout=self.stdout)
@@ -188,7 +181,6 @@ class TestCLILoad(unittest.TestCase):
                 '--update-only': False,
                 '--upload-resources': False,
                 '--insecure': False,
-                '--include-users': False,
                 },
             stdin=BytesIO(b'{"name": "30ish","title":"3.4 times ten","resources":[{"id":"123"}]}\n'),
             stdout=self.stdout)
@@ -205,7 +197,6 @@ class TestCLILoad(unittest.TestCase):
                 '--update-only': False,
                 '--upload-resources': False,
                 '--insecure': False,
-                '--include-users': False,
                 },
             stdin=BytesIO(
                  b'{"name": "30ish","title":"3.4 times ten",'
@@ -224,7 +215,6 @@ class TestCLILoad(unittest.TestCase):
                 '--update-only': True,
                 '--upload-resources': False,
                 '--insecure': False,
-                '--include-users': False,
                 },
             stdin=BytesIO(b'{"name": "34","title":"3.4 times ten"}\n'),
             stdout=self.stdout)
@@ -241,7 +231,6 @@ class TestCLILoad(unittest.TestCase):
                 '--update-only': False,
                 '--upload-resources': False,
                 '--insecure': False,
-                '--include-users': False,
                 },
             stdin=BytesIO(b'{"name": "34","title":"3.4 times ten"}\n'),
             stdout=self.stdout)
@@ -258,7 +247,6 @@ class TestCLILoad(unittest.TestCase):
                 '--update-only': False,
                 '--upload-resources': False,
                 '--insecure': False,
-                '--include-users': False,
                 },
             stdin=BytesIO(b'{"name": "seekrit", "title": "Things"}\n'),
             stdout=self.stdout)
@@ -275,7 +263,6 @@ class TestCLILoad(unittest.TestCase):
                 '--update-only': False,
                 '--upload-resources': False,
                 '--insecure': False,
-                '--include-users': False,
                 },
             stdin=BytesIO(b'{"id": "ab","title":"a balloon"}\n'),
             stdout=self.stdout)
@@ -292,7 +279,6 @@ class TestCLILoad(unittest.TestCase):
                 '--update-only': False,
                 '--upload-resources': False,
                 '--insecure': False,
-                '--include-users': False,
                 },
             stdin=BytesIO(
                 b'{"name": "cd", "title": "Go"}\n'
@@ -317,7 +303,6 @@ class TestCLILoad(unittest.TestCase):
                 '--update-only': False,
                 '--upload-resources': False,
                 '--insecure': False,
-                '--include-users': False,
                 },
             stdin=BytesIO(b'{"id": "used", "title": "here"}\n'),
             stdout=self.stdout)
@@ -334,7 +319,6 @@ class TestCLILoad(unittest.TestCase):
                 '--update-only': False,
                 '--upload-resources': False,
                 '--insecure': False,
-                '--include-users': False,
                 },
             stdin=BytesIO(b'{"id": "unused", "users": []}\n'),
             stdout=self.stdout)
@@ -364,7 +348,6 @@ class TestCLILoad(unittest.TestCase):
                 '--upload-resources': False,
                 '--upload-logo': False,
                 '--insecure': False,
-                '--include-users': False,
             },
             worker_pool=self._mock_worker_pool,
             stdin=BytesIO(
@@ -400,7 +383,6 @@ class TestCLILoad(unittest.TestCase):
                 '--upload-resources': False,
                 '--upload-logo': False,
                 '--insecure': False,
-                '--include-users': False,
             },
             worker_pool=self._mock_worker_pool,
             stdin=BytesIO(
@@ -439,7 +421,6 @@ class TestCLILoad(unittest.TestCase):
                 '--upload-resources': False,
                 '--upload-logo': False,
                 '--insecure': False,
-                '--include-users': False,
             },
             worker_pool=self._mock_worker_pool,
             stdin=BytesIO(

--- a/ckanapi/tests/test_remote.py
+++ b/ckanapi/tests/test_remote.py
@@ -34,7 +34,7 @@ class TestRemoteAction(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         script = os.path.join(os.path.dirname(__file__), 'mock/mock_ckan.py')
-        _mock_ckan = subprocess.Popen(['python2', script],
+        _mock_ckan = subprocess.Popen(['python', script],
             stdout=DEVNULL, stderr=DEVNULL)
         def kill_child():
             try:


### PR DESCRIPTION
feat(cli): added include-users option for group and org dump/load;

- Added `--include-users` argument for group and org dump/load.