### PR TITLE
Fix some errors when executing dumps

### DIFF
--- a/ckanapi/datapackage.py
+++ b/ckanapi/datapackage.py
@@ -84,7 +84,12 @@ def resource_filename(dres):
     # prefer resource names from datapackage metadata, because those have been
     # made unique
     name = dres['name']
-    ext = slugify.slugify(dres['format'])
+    res_format = dres.get('format')
+
+    if not res_format:
+        return name
+
+    ext = slugify.slugify(res_format)
     if name.endswith(ext):
         name = name[:-len(ext)]
     return name + '.' + ext


### PR DESCRIPTION
Hello!

I'm trying to do a dump of an instance but the package is throwing some errors. This PR is to fix whatever is appearing.

#### Problems when logging errors

See #209 


#### KeyError: 'format'

```
Traceback (most recent call last):
  File "/home/pdelboca/Repos/ckanapi/.venv/bin/ckanapi", line 33, in <module>
    sys.exit(load_entry_point('ckanapi', 'console_scripts', 'ckanapi')())
             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/pdelboca/Repos/ckanapi/ckanapi/cli/main.py", line 156, in main
    return dump_things(ckan, thing[0], arguments)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/pdelboca/Repos/ckanapi/ckanapi/cli/dump.py", line 110, in dump_things
    create_datapackage(record, datapackages_path, stderr, apikey)
  File "/home/pdelboca/Repos/ckanapi/ckanapi/datapackage.py", line 67, in create_datapackage
    filename = resource_filename(dres)
               ^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/pdelboca/Repos/ckanapi/ckanapi/datapackage.py", line 87, in resource_filename
    ext = slugify.slugify(dres['format'])
                          ~~~~^^^^^^^^^^
KeyError: 'format'
```