### PR TITLE
Dump All Resource Views

### DIFF
--- a/ckanapi/cli/dump.py
+++ b/ckanapi/cli/dump.py
@@ -194,7 +194,7 @@ def dump_things_worker(ckan, thing, arguments,
                     populate_datastore_res_fields(ckan, res)
             if thing == 'datasets' and arguments['--resource-views']:
                 for res in obj.get('resources', []):
-                    populate_datastore_res_views(ckan, res)
+                    populate_res_views(ckan, res)
             reply(None, obj)
 
 def _worker_command_line(thing, arguments):
@@ -222,23 +222,20 @@ def _worker_command_line(thing, arguments):
         )
 
 
-def populate_datastore_res_views(ckan, res):
+def populate_res_views(ckan, res):
     """
     update resource dict in-place with resource_view_list values
-    in every resource with datastore active using ckan
-    LocalCKAN/RemoteCKAN instance
+    in every resource with views using ckan LocalCKAN/RemoteCKAN instance
     """
-    if not res.get('datastore_active', False):
-        return
     try:
-        ds = ckan.call_action('resource_view_list', {
+        views = ckan.call_action('resource_view_list', {
             'id': res['id'],
             'limit':0})
     except CKANAPIError:
         return
     except NotFound:
         return  # with localckan we'll get the real CKAN exception not a CKANAPIError subclass
-    if not ds:
+    if not views:
         return # return if the resource views list is empty
-    res['resource_views'] = ds
+    res['resource_views'] = views
 


### PR DESCRIPTION
feat(cli): dump all views;

- Dump views for any resource.

The current description of the `--resource-view` flag suggests that all resource views will be dumped. But the code only includes resource view lists for DataStore active resources. There are other views like text and image views which do not need a DataStore active Resource.

Modified the code to include views for any Resource.