### PR TITLE
Fix file uploads on localckan

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,7 +4,7 @@ jobs:
   test:
     strategy:
       matrix:
-        python-version: ["2.7", "3.8"]
+        python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
     runs-on: ubuntu-latest
     container:
       # INFO: python 2 is no longer supported in

--- a/ckanapi/localckan.py
+++ b/ckanapi/localckan.py
@@ -1,4 +1,4 @@
-from cgi import FieldStorage
+from werkzeug.datastructures import FileStorage
 from tempfile import TemporaryFile
 
 from ckanapi.errors import CKANAPIError
@@ -64,10 +64,10 @@ class LocalCKAN(object):
                 except (AttributeError, IOError):
                     f = _write_temp_file(f)
                     to_close.append(f)
-                field_storage = FieldStorage()
-                field_storage.file = f
-                field_storage.filename = filename
-                data_dict[fieldname] = field_storage
+                file_storage = FileStorage()
+                file_storage.stream = f
+                file_storage.filename = filename
+                data_dict[fieldname] = file_storage
 
             return self._get_action(action)(context, data_dict)
         finally:

--- a/ckanapi/localckan.py
+++ b/ckanapi/localckan.py
@@ -1,4 +1,3 @@
-from werkzeug.datastructures import FileStorage
 from tempfile import TemporaryFile
 
 from ckanapi.errors import CKANAPIError
@@ -64,6 +63,9 @@ class LocalCKAN(object):
                 except (AttributeError, IOError):
                     f = _write_temp_file(f)
                     to_close.append(f)
+
+                from werkzeug.datastructures import FileStorage
+
                 file_storage = FileStorage()
                 file_storage.stream = f
                 file_storage.filename = filename

--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ install_requires=[
     'simplejson',
 ]
 tests_require=[
-    'pyfakefs==3.6.1',
+    'pyfakefs==5.3.5',
 ]
 
 


### PR DESCRIPTION
Fixes #211 

`cgi.FieldStorage` has been dropped from ckan since python 3 migration and its going away completely in python 3.13, this just replaces it with werkzeug FileStorage which ckan uses in the core as well.