### PR TITLE
Make API key header configurable

### DIFF
--- a/ckanapi/common.py
+++ b/ckanapi/common.py
@@ -84,9 +84,16 @@ def prepare_action(action, data_dict=None, apikey=None, files=None,
     else:
         data_dict = json.dumps(data_dict).encode('ascii')
         headers['Content-Type'] = 'application/json'
-    if apikey:
+    if apikey is not None:
+        apikey_header = 'X-CKAN-API-Key'
+        if isinstance(apikey, dict):
+            error_msg = "Provided apikey dict must have 'apikey' key."
+            assert 'apikey' in apikey, error_msg
+            apikey_header = apikey.get('header', apikey_header)
+            apikey = apikey.get('apikey')
+
         apikey = str(apikey)
-        headers['X-CKAN-API-Key'] = apikey
+        headers[apikey_header] = apikey
         headers['Authorization'] = apikey
     url = base_url + action
     return url, data_dict, headers

--- a/ckanapi/remoteckan.py
+++ b/ckanapi/remoteckan.py
@@ -31,7 +31,9 @@ class RemoteCKAN(object):
     :param address: the web address of the CKAN instance, e.g.
                     'http://demo.ckan.org', stored as self.address
     :param apikey: the API key to pass as an 'X-CKAN-API-Key' header
-                    when actions are called, stored as self.apikey
+                    when actions are called, stored as self.apikey.
+                    If a dictionary is passed, you may provide an 'apikey'
+                    and 'header' key to specify the key and header name
     :param user_agent: the User-agent to report when making requests
     :param get_only: only use GET requests (default: False)
     :param session: session to use (default: None)

--- a/ckanapi/testappckan.py
+++ b/ckanapi/testappckan.py
@@ -11,7 +11,9 @@ class TestAppCKAN(object):
     :param test_app: the paste.fixture.TestApp instance, stored as
                     self.test_app
     :param apikey: the API key to pass as an 'X-CKAN-API-Key' header
-                    when actions are called, stored as self.apikey
+                    when actions are called, stored as self.apikey.
+                    If a dictionary is passed, you may provide an 'apikey'
+                    and 'header' key to specify the key and header name
     """
     def __init__(self, test_app, apikey=None):
         self.test_app = test_app


### PR DESCRIPTION
Setting the API key header name to `X-CKAN-API-Key` seems problematic. For example, the [data.gov API](https://open.gsa.gov/api/datadotgov/) uses the `x-api-key` as the HTTP header name.

This PR allows users to pass a dictionary instead of just an API key, specifying both the API key and the header name.