### PR TITLE
Replace pkg_resources with importlib.metadata

### DIFF
--- a/ckanapi/version.py
+++ b/ckanapi/version.py
@@ -1,5 +1,3 @@
-import pkg_resources
+from importlib.metadata import version
 
-__version__ = pkg_resources.require("ckanapi")[0].version
-
-
+__version__ = version("ckanapi")


### PR DESCRIPTION
Hi—thanks for providing and maintaining this useful package.

On first use I see the following warnings:
```
../../../.venv/3.13/lib/python3.13/site-packages/ckanapi/version.py:1                                                                                                                                                                                          
  /home/khaeru/.venv/3.13/lib/python3.13/site-packages/ckanapi/version.py:1: DeprecationWarning: pkg_resources is deprecated as an API. See https://setuptools.pypa.io/en/latest/pkg_resources.html                                                           
    import pkg_resources                                                                                                                                                                                                                                       
                                                                                                                                                                                                                                                               
../../../.venv/3.13/lib/python3.13/site-packages/pkg_resources/__init__.py:3149                                                                                                                                                                                
  /home/khaeru/.venv/3.13/lib/python3.13/site-packages/pkg_resources/__init__.py:3149: DeprecationWarning: Deprecated call to `pkg_resources.declare_namespace('sphinxcontrib')`.                                                                             
  Implementing implicit namespace packages (as specified in PEP 420) is preferred to `pkg_resources.declare_namespace`. See https://setuptools.pypa.io/en/latest/references/keywords.html#keyword-namespace-packages                                          
    declare_namespace(pkg)                                                                                                                                                                                                                                     
```

This PR adjusts—[as suggested in the setuptools docs](https://setuptools.pypa.io/en/latest/pkg_resources.html)—to use [`importlib.metadata.version()`](https://docs.python.org/3/library/importlib.metadata.html#importlib.metadata.version).

Please let me know if there are any other steps I should take to help get this merged.