### PR TITLE
Add pickle support to ActionShortcut

### DIFF
--- a/ckanapi/tests/test_common.py
+++ b/ckanapi/tests/test_common.py
@@ -1,0 +1,20 @@
+import pickle
+import unittest
+
+from ckanapi import RemoteCKAN
+from ckanapi.common import ActionShortcut
+
+
+class TestCommon(unittest.TestCase):
+    def test_pickling(self):
+        with RemoteCKAN('http://localhost:8901') as ckan:
+            action_shortcut = ActionShortcut(ckan)
+            # Verifies that pickling seems to work. Previously, this could
+            # result in errors like:
+            # TypeError: ActionShortcut.__getattr__.<locals>.action() takes 0
+            #   positional arguments but 1 was given
+            pickled = pickle.dumps(action_shortcut)
+            unpickled = pickle.loads(pickled)
+            # Partially check that the pickling+unpickling worked
+            self.assertEqual(action_shortcut._ckan.address,
+                             unpickled._ckan.address)


### PR DESCRIPTION
On my setup (Mac), multiprocessing defaults to pickling + unpickling state from the main process to worker processes. Pickling doesn't/can't support local functions. Because ActionShortcut's __getattr__ returns a local function regardless of the attribute name that's requested, instances of that class cannot be pickled without this fix. 

The solution is to implement a custom __getstate__ and __setstate__, to state how ActionShortcut should be pickled/unpickled.

Includes a basic test.

https://docs.python.org/3/library/pickle.html#object.__getstate__
https://docs.python.org/3/library/multiprocessing.html