### PR TITLE
Fix trailing hyphen in resource_filename when nFix trailing hyphen in resource_filename when slugified name ends with extensioname ends with slugifie…

### DIFF
--- a/ckanapi/datapackage.py
+++ b/ckanapi/datapackage.py
@@ -81,12 +81,11 @@ def create_datapackage(record, base_path, stderr, apikey):
 
 
 def resource_filename(dres):
-    # prefer resource names from datapackage metadata, because those have been
-    # made unique
     name = dres['name']
     ext = slugify.slugify(dres['format'])
     if name.endswith(ext):
         name = name[:-len(ext)]
+    name = name.rstrip('-.')   # fix: remove trailing hyphen or dot
     return name + '.' + ext
 
 

--- a/ckanapi/tests/test_datapackage.py
+++ b/ckanapi/tests/test_datapackage.py
@@ -258,7 +258,29 @@ class TestResourceFilename(unittest.TestCase):
         filename = resource_filename(dres=datapackage_resource)
 
         assert filename == u'image-1.png'
+        
+class TestResourceFilename(unittest.TestCase):
+    def test_simple(self):
+        datapackage_resource = {
+            u'title': u'Image 1',
+            u'name': u'image-1',
+            u'format': u'PNG'
+        }
 
+        filename = resource_filename(dres=datapackage_resource)
+
+        assert filename == u'image-1.png'
+
+    def test_no_trailing_hyphen_before_extension(self):
+        datapackage_resource = {
+            u'title': u'S_ptarmigan_counts_readme.pdf',
+            u'name': u's-ptarmigan-counts-readme-pdf',
+            u'format': u'PDF'
+        }
+
+        filename = resource_filename(dres=datapackage_resource)
+
+        assert filename == u's-ptarmigan-counts-readme.pdf'
 
 class TestPopulateSchemaFromDatastore(unittest.TestCase):
     def test_simple(self):


### PR DESCRIPTION
…d extension## Problem
A resource titled "S_ptarmigan_counts_readme.pdf" produces the path 
"data/s-ptarmigan-counts-readme-.pdf" instead of 
"data/s-ptarmigan-counts-readme.pdf".

## Root Cause
In resource_filename(), after stripping the slugified extension from 
the name, a trailing hyphen is left behind before the extension is 
re-appended.

## Fix
Added name.rstrip('-.') after stripping the extension to remove any 
trailing hyphens or dots.

## Testing
Added a test case to TestResourceFilename reproducing the exact 
scenario described above.