### PR TITLE
Append Users for Groups/Orgs

### DIFF
--- a/ckanapi/cli/load.py
+++ b/ckanapi/cli/load.py
@@ -220,10 +220,13 @@ def load_things_worker(ckan, thing, arguments,
                             resource_views[r['id']] = r.pop('resource_views', [])
                         if arguments['--datastore-fields']:
                             datastore_fields[r['id']] = r.pop('datastore_fields', [])
+                if thing in ('group', 'organization') and obj.get('users') and arguments['--append-users']:
+                    group_users = obj.pop('users', [])
                 if existing:
                     r = ckan.call_action(thing_update, obj,
                                          requests_kwargs=requests_kwargs)
                 else:
+                    # FIXME: add ignore_not_sysadmin to creator_user_id to ckan core....
                     r = ckan.call_action(thing_create, obj,
                                          requests_kwargs=requests_kwargs)
                 if thing == 'datasets' and 'resources' in obj:
@@ -235,14 +238,16 @@ def load_things_worker(ckan, thing, arguments,
                         _upload_resources(ckan, obj, arguments)
                     if arguments['--resource-views'] and resource_views:  # check if it is needed to create resource views when creating/updating packages
                         created_views, updated_views, skipped_views = _load_resource_views(ckan, resource_views, arguments)
-                if thing in ['groups','organizations'] and 'image_display_url' in obj:  # load images for groups and organizations
-                    if arguments['--upload-logo']:
+                if thing in ('groups', 'organizations'):
+                    if 'image_display_url' in obj and arguments['--upload-logo']:  # load images for groups and organizations
                         users = obj['users']
                         obj = _upload_logo(ckan,obj)
                         obj.pop('image_upload')
                         obj['users'] = users
                         ckan.call_action(thing_update, obj,
                                          requests_kwargs=requests_kwargs)
+                    if arguments['--append-users'] and group_users:  # check if it is needed to append group/org users
+                        set_members = _load_group_members(ckan, group_users, arguments, thing, r['id'])
                 if thing == 'users' and arguments['--api-tokens'] and api_token_list:  # check if it is needed to create user api tokens when creating/updating users
                     created_tokens = _load_user_api_tokens(ckan, api_token_list, arguments)
             except ValidationError as e:
@@ -269,6 +274,8 @@ def load_things_worker(ckan, thing, arguments,
                         log_obj['created_datastore_tables'] = created_tables
                     if skipped_tables:
                         log_obj['skipped_datastore_tables'] = skipped_tables
+                if thing in ('groups', 'organizations') and arguments['--append-users'] and group_users and set_members:
+                    log_obj['set_members'] = set_members
                 reply(act, None, log_obj)
 
 def _worker_command_line(thing, arguments):
@@ -295,6 +302,7 @@ def _worker_command_line(thing, arguments):
         + b('--api-tokens')
         + b('--datastore-fields')
         + b('--resource-views')
+        + b('--append-users')
         )
 
 
@@ -456,3 +464,27 @@ def _load_user_api_tokens(ckan, api_token_list, arguments):
             requests_kwargs=requests_kwargs)
         created_tokens.append(token['name'])
     return created_tokens
+
+
+def _load_group_members(ckan, user_list, arguments, thing, obj_id):
+    """
+    Appends users as members for Groups/Organizations
+    """
+    requests_kwargs = None
+    if arguments['--insecure']:
+        requests_kwargs = {'verify': False}
+    set_members = []
+    action = 'group_member_create' if thing == 'group' \
+        else 'organization_member_create'
+    for user in user_list:
+        # exceptions handled in load_things_worker
+        ckan.call_action(
+            action,
+            {
+                'id': obj_id,
+                'username': user['name'],
+                'role': user['capacity'],
+            },
+            requests_kwargs=requests_kwargs)
+        set_members.append('%s[%s]' % (user['name'], user['capacity']))
+    return set_members

--- a/ckanapi/cli/load.py
+++ b/ckanapi/cli/load.py
@@ -229,7 +229,6 @@ def load_things_worker(ckan, thing, arguments,
                     r = ckan.call_action(thing_update, obj,
                                          requests_kwargs=requests_kwargs)
                 else:
-                    # FIXME: add ignore_not_sysadmin to creator_user_id to ckan core....
                     r = ckan.call_action(thing_create, obj,
                                          requests_kwargs=requests_kwargs)
                 if thing == 'datasets' and 'resources' in obj:

--- a/ckanapi/cli/load.py
+++ b/ckanapi/cli/load.py
@@ -223,7 +223,7 @@ def load_things_worker(ckan, thing, arguments,
                             datastore_fields[r['id']] = r.pop('datastore_fields', [])
                 if thing in ('groups', 'organizations') and obj.get('users'):
                     group_users = obj.pop('users', [])
-                    if not arguments['--append-users']:
+                    if not arguments['--append-users'] and arguments['--include-users']:
                         obj['users'] = group_users
                 if existing:
                     r = ckan.call_action(thing_update, obj,
@@ -278,8 +278,8 @@ def load_things_worker(ckan, thing, arguments,
                         log_obj['skipped_datastore_tables'] = skipped_tables
                 if thing in ('groups', 'organizations'):
                     if arguments['--append-users'] and group_users and set_members:
-                        log_obj['set_members'] = set_members
-                    elif group_users:
+                        log_obj['added_members'] = set_members
+                    elif arguments['--include-users'] and group_users:
                         log_obj['set_members'] = ['%s[%s]' % (m['name'], m['capacity']) for m in group_users]
                 reply(act, None, log_obj)
 
@@ -307,6 +307,7 @@ def _worker_command_line(thing, arguments):
         + b('--api-tokens')
         + b('--datastore-fields')
         + b('--resource-views')
+        + b('--include-users')
         + b('--append-users')
         )
 

--- a/ckanapi/cli/load.py
+++ b/ckanapi/cli/load.py
@@ -212,6 +212,7 @@ def load_things_worker(ckan, thing, arguments,
                 # do not send resource_views & datastore_fields to package actions
                 resource_views = {}
                 datastore_fields = {}
+                group_users = []
                 if thing == 'datasets' and obj.get('resources'):
                     for r in obj['resources']:
                         # NOTE: will only work with existing Resource IDs in the input,
@@ -220,8 +221,10 @@ def load_things_worker(ckan, thing, arguments,
                             resource_views[r['id']] = r.pop('resource_views', [])
                         if arguments['--datastore-fields']:
                             datastore_fields[r['id']] = r.pop('datastore_fields', [])
-                if thing in ('group', 'organization') and obj.get('users') and arguments['--append-users']:
+                if thing in ('groups', 'organizations') and obj.get('users'):
                     group_users = obj.pop('users', [])
+                    if not arguments['--append-users']:
+                        obj['users'] = group_users
                 if existing:
                     r = ckan.call_action(thing_update, obj,
                                          requests_kwargs=requests_kwargs)
@@ -274,8 +277,11 @@ def load_things_worker(ckan, thing, arguments,
                         log_obj['created_datastore_tables'] = created_tables
                     if skipped_tables:
                         log_obj['skipped_datastore_tables'] = skipped_tables
-                if thing in ('groups', 'organizations') and arguments['--append-users'] and group_users and set_members:
-                    log_obj['set_members'] = set_members
+                if thing in ('groups', 'organizations'):
+                    if arguments['--append-users'] and group_users and set_members:
+                        log_obj['set_members'] = set_members
+                    elif group_users:
+                        log_obj['set_members'] = ['%s[%s]' % (m['name'], m['capacity']) for m in group_users]
                 reply(act, None, log_obj)
 
 def _worker_command_line(thing, arguments):

--- a/ckanapi/cli/main.py
+++ b/ckanapi/cli/main.py
@@ -30,7 +30,7 @@ Usage:
           [[-c CONFIG] [-u USER] | -r SITE_URL [-a APIKEY] [--insecure]]
   ckanapi load (groups | organizations)
           [--upload-logo] [-I JSONL_INPUT] [-s START] [-m MAX]
-          [-p PROCESSES] [-l LOG_FILE] [-n | -o] [-qwzU]
+          [-p PROCESSES] [-l LOG_FILE] [-n | -o] [-qwzUA]
           [[-c CONFIG] [-u USER] | -r SITE_URL [-a APIKEY] [--insecure]]
   ckanapi load users
           [-I JSONL_INPUT] [-s START] [-m MAX] [-p PROCESSES] [-l LOG_FILE]
@@ -92,6 +92,8 @@ Options:
   -u --ckan-user=USER       perform actions as user with this name, uses the
                             site sysadmin user when not specified
   -U --include-users        include users of a group/organization
+  -A --append-users         adds users to a group/organization instead of truncating them.
+                            Mutually exclusive with -U
   --api-tokens              export API Token information along with
                             user metadata as api_token_list lists (dump).
                             create API Tokens for users (load).

--- a/ckanapi/cli/main.py
+++ b/ckanapi/cli/main.py
@@ -30,7 +30,7 @@ Usage:
           [[-c CONFIG] [-u USER] | -r SITE_URL [-a APIKEY] [--insecure]]
   ckanapi load (groups | organizations)
           [--upload-logo] [-I JSONL_INPUT] [-s START] [-m MAX]
-          [-p PROCESSES] [-l LOG_FILE] [-n | -o] [-qwzUA]
+          [-p PROCESSES] [-l LOG_FILE] [-n | -o] [-qwz] [--include-users | --append-users]
           [[-c CONFIG] [-u USER] | -r SITE_URL [-a APIKEY] [--insecure]]
   ckanapi load users
           [-I JSONL_INPUT] [-s START] [-m MAX] [-p PROCESSES] [-l LOG_FILE]
@@ -91,9 +91,9 @@ Options:
                             record is number 1 [default: 1]
   -u --ckan-user=USER       perform actions as user with this name, uses the
                             site sysadmin user when not specified
-  -U --include-users        include users of a group/organization
+  -U --include-users        include users of a group/organization. Will fully replace
+                            any existing users during load.
   -A --append-users         adds users to a group/organization instead of truncating them.
-                            Mutually exclusive with -U
   --api-tokens              export API Token information along with
                             user metadata as api_token_list lists (dump).
                             create API Tokens for users (load).

--- a/ckanapi/tests/test_cli_load.py
+++ b/ckanapi/tests/test_cli_load.py
@@ -30,23 +30,26 @@ class MockCKAN(object):
                     '30ish': {'id': '34', 'title': "Thirty-four"},
                     '34': {'id': '34', 'title': "Thirty-four"},
                     '46': {'id': '46', 'name': '46', 'title': 'Forty-six'},
-                    },
+                },
                 'group_show': {
                     'ab': {'title': "ABBA"},
-                    },
+                },
                 'organization_show': {
                     'cd': {'id': 'cd', 'title': "Super Trouper"},
                     'used': {'users': ['people']},
                     'unused': {'users': ['people']},
-                    },
+                    'mems': {'id': 'mems', 'name': 'mems',
+                             "users": [{"capacity": "admin", "name": "test-user-admin"},
+                                       {"capacity": "editor", "name": "test-user"}]},
+                },
                 'package_create': {
                     None: {'id': 'some-generated-uuid', 'name': 'something-new'},
                     '46': {'id': '46', 'name': '46'},
-                    },
+                },
                 'package_update': {
                     '34': {'id': '34', 'name': 'something-updated'},
                     '46': {'id': '46', 'name': '46'},
-                    },
+                },
                 'resource_view_show': {
                     '456': {'description': 'Test view', 'package_id': '46', 'resource_id': '456'}
                 },
@@ -66,15 +69,20 @@ class MockCKAN(object):
                 },
                 'group_update': {
                     'ab': {'id': 'ab', 'name': 'group-updated'},
-                    },
+                },
                 'organization_update': {
                     'cd': {'id': 'cd', 'name': 'org-updated'},
                     'used': {'id': 'used', 'name': 'users-unchanged'},
                     'unused': {'id': 'unused', 'name': 'users-cleared'},
-                    },
+                    'mems': {'id': 'mems', 'name': 'mems', "users": [{"capacity": "admin", "name": "test-user-admin"}]},
+                },
                 'organization_create': {
                     None: {'id': 'some-generated-uuid', 'name': 'org-created'},
-                    },
+                    'mems': {'id': 'mems', 'name': 'mems', "users": [{"capacity": "editor", "name": "test-user"}]},
+                },
+                'organization_member_create': {
+                    'mems': {'id': 'mems', 'role': 'admin', 'username': 'test-user-admin'}
+                },
                 'user_show': {
                     'test_user': {'id': 'test_user', 'name': 'test_user'},
                 },
@@ -105,6 +113,7 @@ class TestCLILoad(unittest.TestCase):
                 '--insecure': False,
                 '--resource-views': False,
                 '--datastore-fields': False,
+                '--append-users': False,
                 },
             stdin=BytesIO(b'{"name": "45","title":"Forty-five"}\n'),
             stdout=self.stdout)
@@ -123,6 +132,7 @@ class TestCLILoad(unittest.TestCase):
                 '--insecure': False,
                 '--resource-views': False,
                 '--datastore-fields': False,
+                '--append-users': False,
                 },
             stdin=BytesIO(b'{"name": "45","title":"Forty-five","resources":[{"id":"123"}]}\n'),
             stdout=self.stdout)
@@ -141,6 +151,7 @@ class TestCLILoad(unittest.TestCase):
                 '--insecure': False,
                 '--resource-views': False,
                 '--datastore-fields': False,
+                '--append-users': False,
                 },
             stdin=BytesIO(
                  b'{"name": "45","title":"Forty-five",'
@@ -184,6 +195,7 @@ class TestCLILoad(unittest.TestCase):
                 '--insecure': False,
                 '--resource-views': True,
                 '--datastore-fields': False,
+                '--append-users': False,
                 },
             stdin=BytesIO(json.dumps(payload).encode()),
             stdout=self.stdout)
@@ -221,6 +233,7 @@ class TestCLILoad(unittest.TestCase):
                 '--insecure': False,
                 '--resource-views': False,
                 '--datastore-fields': True,
+                '--append-users': False,
                 },
             stdin=BytesIO(json.dumps(payload).encode()),
             stdout=self.stdout)
@@ -258,6 +271,7 @@ class TestCLILoad(unittest.TestCase):
                 '--insecure': False,
                 '--resource-views': False,
                 '--datastore-fields': True,
+                '--append-users': False,
                 },
             stdin=BytesIO(json.dumps(payload).encode()),
             stdout=self.stdout)
@@ -276,6 +290,7 @@ class TestCLILoad(unittest.TestCase):
                 '--insecure': False,
                 '--resource-views': False,
                 '--datastore-fields': False,
+                '--append-users': False,
                 },
             stdin=BytesIO(b'{"name": "45","title":"Forty-five"}\n'),
             stdout=self.stdout)
@@ -294,6 +309,7 @@ class TestCLILoad(unittest.TestCase):
                 '--insecure': False,
                 '--resource-views': False,
                 '--datastore-fields': False,
+                '--append-users': False,
                 },
             stdin=BytesIO(b'{}\n'),
             stdout=self.stdout)
@@ -311,6 +327,7 @@ class TestCLILoad(unittest.TestCase):
                 '--insecure': False,
                 '--resource-views': False,
                 '--datastore-fields': False,
+                '--append-users': False,
                 },
             stdin=BytesIO(b'{"name": "45","title":"Forty-five"}\n'),
             stdout=self.stdout)
@@ -328,6 +345,7 @@ class TestCLILoad(unittest.TestCase):
                 '--insecure': False,
                 '--resource-views': False,
                 '--datastore-fields': False,
+                '--append-users': False,
                 },
             stdin=BytesIO(b'{"name": "30ish","title":"3.4 times ten"}\n'),
             stdout=self.stdout)
@@ -346,6 +364,7 @@ class TestCLILoad(unittest.TestCase):
                 '--insecure': False,
                 '--resource-views': False,
                 '--datastore-fields': False,
+                '--append-users': False,
                 },
             stdin=BytesIO(b'{"name": "30ish","title":"3.4 times ten","resources":[{"id":"123"}]}\n'),
             stdout=self.stdout)
@@ -364,6 +383,7 @@ class TestCLILoad(unittest.TestCase):
                 '--insecure': False,
                 '--resource-views': False,
                 '--datastore-fields': False,
+                '--append-users': False,
                 },
             stdin=BytesIO(
                  b'{"name": "30ish","title":"3.4 times ten",'
@@ -407,6 +427,7 @@ class TestCLILoad(unittest.TestCase):
                 '--insecure': False,
                 '--resource-views': True,
                 '--datastore-fields': False,
+                '--append-users': False,
                 },
             stdin=BytesIO(json.dumps(payload).encode()),
             stdout=self.stdout)
@@ -448,6 +469,7 @@ class TestCLILoad(unittest.TestCase):
                 '--insecure': False,
                 '--resource-views': True,
                 '--datastore-fields': False,
+                '--append-users': False,
                 },
             stdin=BytesIO(json.dumps(payload).encode()),
             stdout=self.stdout)
@@ -485,6 +507,7 @@ class TestCLILoad(unittest.TestCase):
                 '--insecure': False,
                 '--resource-views': False,
                 '--datastore-fields': True,
+                '--append-users': False,
                 },
             stdin=BytesIO(json.dumps(payload).encode()),
             stdout=self.stdout)
@@ -522,6 +545,7 @@ class TestCLILoad(unittest.TestCase):
                 '--insecure': False,
                 '--resource-views': False,
                 '--datastore-fields': True,
+                '--append-users': False,
                 },
             stdin=BytesIO(json.dumps(payload).encode()),
             stdout=self.stdout)
@@ -559,6 +583,7 @@ class TestCLILoad(unittest.TestCase):
                     '--insecure': False,
                     '--resource-views': False,
                     '--datastore-fields': True,
+                    '--append-users': False,
                     },
                 stdin=BytesIO(json.dumps(payload).encode()),
                 stdout=self.stdout)
@@ -595,6 +620,7 @@ class TestCLILoad(unittest.TestCase):
                     '--insecure': False,
                     '--resource-views': True,
                     '--datastore-fields': False,
+                    '--append-users': False,
                     },
                 stdin=BytesIO(json.dumps(payload).encode()),
                 stdout=self.stdout)
@@ -608,6 +634,7 @@ class TestCLILoad(unittest.TestCase):
                 '--insecure': False,
                 '--resource-views': False,
                 '--datastore-fields': False,
+                '--append-users': False,
                 },
             stdin=BytesIO(b'{"name": "34","title":"3.4 times ten"}\n'),
             stdout=self.stdout)
@@ -626,6 +653,7 @@ class TestCLILoad(unittest.TestCase):
                 '--insecure': False,
                 '--resource-views': False,
                 '--datastore-fields': False,
+                '--append-users': False,
                 },
             stdin=BytesIO(b'{"name": "34","title":"3.4 times ten"}\n'),
             stdout=self.stdout)
@@ -644,6 +672,7 @@ class TestCLILoad(unittest.TestCase):
                 '--insecure': False,
                 '--resource-views': False,
                 '--datastore-fields': False,
+                '--append-users': False,
                 },
             stdin=BytesIO(b'{"name": "seekrit", "title": "Things"}\n'),
             stdout=self.stdout)
@@ -662,6 +691,7 @@ class TestCLILoad(unittest.TestCase):
                 '--insecure': False,
                 '--resource-views': False,
                 '--datastore-fields': False,
+                '--append-users': False,
                 },
             stdin=BytesIO(b'{"id": "ab","title":"a balloon"}\n'),
             stdout=self.stdout)
@@ -680,6 +710,7 @@ class TestCLILoad(unittest.TestCase):
                 '--insecure': False,
                 '--resource-views': False,
                 '--datastore-fields': False,
+                '--append-users': False,
                 },
             stdin=BytesIO(
                 b'{"name": "cd", "title": "Go"}\n'
@@ -706,6 +737,7 @@ class TestCLILoad(unittest.TestCase):
                 '--insecure': False,
                 '--resource-views': False,
                 '--datastore-fields': False,
+                '--append-users': False,
                 },
             stdin=BytesIO(b'{"id": "used", "title": "here"}\n'),
             stdout=self.stdout)
@@ -724,6 +756,7 @@ class TestCLILoad(unittest.TestCase):
                 '--insecure': False,
                 '--resource-views': False,
                 '--datastore-fields': False,
+                '--append-users': False,
                 },
             stdin=BytesIO(b'{"id": "unused", "users": []}\n'),
             stdout=self.stdout)
@@ -733,6 +766,47 @@ class TestCLILoad(unittest.TestCase):
         self.assertEqual(action, 'update')
         self.assertEqual(error, None)
         self.assertEqual(data, {'id': 'unused', 'name': 'users-cleared'})
+
+    def test_update_organization_with_users_appended(self):
+        load_things_worker(self.ckan, 'organizations', {
+                '--create-only': True,
+                '--update-only': False,
+                '--upload-resources': False,
+                '--insecure': False,
+                '--resource-views': False,
+                '--datastore-fields': False,
+                '--append-users': False,
+                },
+            stdin=BytesIO(b'{"id": "mems", "name": "mems", "users": [{"capacity": "editor", "name": "test-user"}]}\n'),
+            stdout=self.stdout)
+        response = self.stdout.getvalue()
+        self.assertEqual(response[-1:], b'\n')
+        timstamp, action, error, data = json.loads(response.decode('UTF-8'))
+        self.assertEqual(action, 'create')
+        self.assertEqual(error, None)
+        self.assertEqual(data, {'id': 'mems', 'name': 'mems', "set_members": ["test-user[editor]"]})
+
+        self.stdout.seek(0)
+        self.stdout.truncate(0)
+
+        load_things_worker(self.ckan, 'organizations', {
+                '--create-only': False,
+                '--update-only': True,
+                '--upload-resources': False,
+                '--insecure': False,
+                '--resource-views': False,
+                '--datastore-fields': False,
+                '--append-users': True,
+                },
+            stdin=BytesIO(b'{"id": "mems", "name": "mems", "users": [{"capacity": "admin", "name": "test-user-admin"}]}\n'),
+            stdout=self.stdout)
+        response = self.stdout.getvalue()
+        self.assertEqual(response[-1:], b'\n')
+
+        timstamp, action, error, data = json.loads(response.decode('UTF-8'))
+        self.assertEqual(action, 'update')
+        self.assertEqual(error, None)
+        self.assertEqual(data, {'id': 'mems', 'name': 'mems', "set_members": ["test-user-admin[admin]"]})
 
     def test_parent_load_two(self):
         load_things(self.ckan, 'datasets', {
@@ -756,6 +830,7 @@ class TestCLILoad(unittest.TestCase):
                 '--api-tokens': False,
                 '--resource-views': False,
                 '--datastore-fields': False,
+                '--append-users': False,
             },
             worker_pool=self._mock_worker_pool,
             stdin=BytesIO(
@@ -794,6 +869,7 @@ class TestCLILoad(unittest.TestCase):
                 '--api-tokens': False,
                 '--resource-views': False,
                 '--datastore-fields': False,
+                '--append-users': False,
             },
             worker_pool=self._mock_worker_pool,
             stdin=BytesIO(
@@ -835,6 +911,7 @@ class TestCLILoad(unittest.TestCase):
                 '--api-tokens': False,
                 '--resource-views': False,
                 '--datastore-fields': False,
+                '--append-users': False,
             },
             worker_pool=self._mock_worker_pool,
             stdin=BytesIO(

--- a/ckanapi/tests/test_cli_load.py
+++ b/ckanapi/tests/test_cli_load.py
@@ -13,7 +13,7 @@ class MockCKAN(object):
             raise ValidationError({'name': 'That URL is already in use.'})
         if name == 'organization_update':
             if data_dict['id'] == 'used' and data_dict.get('users') != [
-                    'people']:
+                    {"capacity": "editor", "name": "test-user"}]:
                 raise ValidationError({'users': 'should be unchanged'})
             if data_dict['id'] == 'unused' and data_dict.get('users') != []:
                 raise ValidationError({'users': 'should be cleared'})
@@ -36,8 +36,8 @@ class MockCKAN(object):
                 },
                 'organization_show': {
                     'cd': {'id': 'cd', 'title': "Super Trouper"},
-                    'used': {'users': ['people']},
-                    'unused': {'users': ['people']},
+                    'used': {'users': [{"capacity": "editor", "name": "test-user"}]},
+                    'unused': {'users': [{"capacity": "editor", "name": "test-user"}]},
                     'mems': {'id': 'mems', 'name': 'mems',
                              "users": [{"capacity": "admin", "name": "test-user-admin"},
                                        {"capacity": "editor", "name": "test-user"}]},

--- a/ckanapi/tests/test_cli_load.py
+++ b/ckanapi/tests/test_cli_load.py
@@ -11,12 +11,6 @@ class MockCKAN(object):
             raise NotAuthorized('naughty user')
         if name == 'package_create' and data_dict.get('name') == '34':
             raise ValidationError({'name': 'That URL is already in use.'})
-        if name == 'organization_update':
-            if data_dict['id'] == 'used' and data_dict.get('users') != [
-                    {"capacity": "editor", "name": "test-user"}]:
-                raise ValidationError({'users': 'should be unchanged'})
-            if data_dict['id'] == 'unused' and data_dict.get('users') != []:
-                raise ValidationError({'users': 'should be cleared'})
         if name == 'resource_view_show' and data_dict['id'] == '123':
             raise NotFound('no resource view with ID 123')
         if name == 'datastore_search' and (data_dict['resource_id'] == '123' or data_dict['resource_id'] == '111'):
@@ -113,6 +107,7 @@ class TestCLILoad(unittest.TestCase):
                 '--insecure': False,
                 '--resource-views': False,
                 '--datastore-fields': False,
+                '--include-users': False,
                 '--append-users': False,
                 },
             stdin=BytesIO(b'{"name": "45","title":"Forty-five"}\n'),
@@ -132,6 +127,7 @@ class TestCLILoad(unittest.TestCase):
                 '--insecure': False,
                 '--resource-views': False,
                 '--datastore-fields': False,
+                '--include-users': False,
                 '--append-users': False,
                 },
             stdin=BytesIO(b'{"name": "45","title":"Forty-five","resources":[{"id":"123"}]}\n'),
@@ -151,6 +147,7 @@ class TestCLILoad(unittest.TestCase):
                 '--insecure': False,
                 '--resource-views': False,
                 '--datastore-fields': False,
+                '--include-users': False,
                 '--append-users': False,
                 },
             stdin=BytesIO(
@@ -195,6 +192,7 @@ class TestCLILoad(unittest.TestCase):
                 '--insecure': False,
                 '--resource-views': True,
                 '--datastore-fields': False,
+                '--include-users': False,
                 '--append-users': False,
                 },
             stdin=BytesIO(json.dumps(payload).encode()),
@@ -233,6 +231,7 @@ class TestCLILoad(unittest.TestCase):
                 '--insecure': False,
                 '--resource-views': False,
                 '--datastore-fields': True,
+                '--include-users': False,
                 '--append-users': False,
                 },
             stdin=BytesIO(json.dumps(payload).encode()),
@@ -271,6 +270,7 @@ class TestCLILoad(unittest.TestCase):
                 '--insecure': False,
                 '--resource-views': False,
                 '--datastore-fields': True,
+                '--include-users': False,
                 '--append-users': False,
                 },
             stdin=BytesIO(json.dumps(payload).encode()),
@@ -290,6 +290,7 @@ class TestCLILoad(unittest.TestCase):
                 '--insecure': False,
                 '--resource-views': False,
                 '--datastore-fields': False,
+                '--include-users': False,
                 '--append-users': False,
                 },
             stdin=BytesIO(b'{"name": "45","title":"Forty-five"}\n'),
@@ -309,6 +310,7 @@ class TestCLILoad(unittest.TestCase):
                 '--insecure': False,
                 '--resource-views': False,
                 '--datastore-fields': False,
+                '--include-users': False,
                 '--append-users': False,
                 },
             stdin=BytesIO(b'{}\n'),
@@ -327,6 +329,7 @@ class TestCLILoad(unittest.TestCase):
                 '--insecure': False,
                 '--resource-views': False,
                 '--datastore-fields': False,
+                '--include-users': False,
                 '--append-users': False,
                 },
             stdin=BytesIO(b'{"name": "45","title":"Forty-five"}\n'),
@@ -345,6 +348,7 @@ class TestCLILoad(unittest.TestCase):
                 '--insecure': False,
                 '--resource-views': False,
                 '--datastore-fields': False,
+                '--include-users': False,
                 '--append-users': False,
                 },
             stdin=BytesIO(b'{"name": "30ish","title":"3.4 times ten"}\n'),
@@ -364,6 +368,7 @@ class TestCLILoad(unittest.TestCase):
                 '--insecure': False,
                 '--resource-views': False,
                 '--datastore-fields': False,
+                '--include-users': False,
                 '--append-users': False,
                 },
             stdin=BytesIO(b'{"name": "30ish","title":"3.4 times ten","resources":[{"id":"123"}]}\n'),
@@ -383,6 +388,7 @@ class TestCLILoad(unittest.TestCase):
                 '--insecure': False,
                 '--resource-views': False,
                 '--datastore-fields': False,
+                '--include-users': False,
                 '--append-users': False,
                 },
             stdin=BytesIO(
@@ -427,6 +433,7 @@ class TestCLILoad(unittest.TestCase):
                 '--insecure': False,
                 '--resource-views': True,
                 '--datastore-fields': False,
+                '--include-users': False,
                 '--append-users': False,
                 },
             stdin=BytesIO(json.dumps(payload).encode()),
@@ -469,6 +476,7 @@ class TestCLILoad(unittest.TestCase):
                 '--insecure': False,
                 '--resource-views': True,
                 '--datastore-fields': False,
+                '--include-users': False,
                 '--append-users': False,
                 },
             stdin=BytesIO(json.dumps(payload).encode()),
@@ -507,6 +515,7 @@ class TestCLILoad(unittest.TestCase):
                 '--insecure': False,
                 '--resource-views': False,
                 '--datastore-fields': True,
+                '--include-users': False,
                 '--append-users': False,
                 },
             stdin=BytesIO(json.dumps(payload).encode()),
@@ -545,6 +554,7 @@ class TestCLILoad(unittest.TestCase):
                 '--insecure': False,
                 '--resource-views': False,
                 '--datastore-fields': True,
+                '--include-users': False,
                 '--append-users': False,
                 },
             stdin=BytesIO(json.dumps(payload).encode()),
@@ -583,6 +593,7 @@ class TestCLILoad(unittest.TestCase):
                     '--insecure': False,
                     '--resource-views': False,
                     '--datastore-fields': True,
+                    '--include-users': False,
                     '--append-users': False,
                     },
                 stdin=BytesIO(json.dumps(payload).encode()),
@@ -620,6 +631,7 @@ class TestCLILoad(unittest.TestCase):
                     '--insecure': False,
                     '--resource-views': True,
                     '--datastore-fields': False,
+                    '--include-users': False,
                     '--append-users': False,
                     },
                 stdin=BytesIO(json.dumps(payload).encode()),
@@ -634,6 +646,7 @@ class TestCLILoad(unittest.TestCase):
                 '--insecure': False,
                 '--resource-views': False,
                 '--datastore-fields': False,
+                '--include-users': False,
                 '--append-users': False,
                 },
             stdin=BytesIO(b'{"name": "34","title":"3.4 times ten"}\n'),
@@ -653,6 +666,7 @@ class TestCLILoad(unittest.TestCase):
                 '--insecure': False,
                 '--resource-views': False,
                 '--datastore-fields': False,
+                '--include-users': False,
                 '--append-users': False,
                 },
             stdin=BytesIO(b'{"name": "34","title":"3.4 times ten"}\n'),
@@ -672,6 +686,7 @@ class TestCLILoad(unittest.TestCase):
                 '--insecure': False,
                 '--resource-views': False,
                 '--datastore-fields': False,
+                '--include-users': False,
                 '--append-users': False,
                 },
             stdin=BytesIO(b'{"name": "seekrit", "title": "Things"}\n'),
@@ -691,6 +706,7 @@ class TestCLILoad(unittest.TestCase):
                 '--insecure': False,
                 '--resource-views': False,
                 '--datastore-fields': False,
+                '--include-users': False,
                 '--append-users': False,
                 },
             stdin=BytesIO(b'{"id": "ab","title":"a balloon"}\n'),
@@ -710,6 +726,7 @@ class TestCLILoad(unittest.TestCase):
                 '--insecure': False,
                 '--resource-views': False,
                 '--datastore-fields': False,
+                '--include-users': False,
                 '--append-users': False,
                 },
             stdin=BytesIO(
@@ -729,7 +746,7 @@ class TestCLILoad(unittest.TestCase):
         self.assertEqual(error, None)
         self.assertEqual(data, {'id': 'some-generated-uuid', 'name': 'org-created'})
 
-    def test_update_organization_with_users_unchanged(self):
+    def test_update_organization_with_no_users(self):
         load_things_worker(self.ckan, 'organizations', {
                 '--create-only': False,
                 '--update-only': False,
@@ -737,9 +754,10 @@ class TestCLILoad(unittest.TestCase):
                 '--insecure': False,
                 '--resource-views': False,
                 '--datastore-fields': False,
+                '--include-users': False,
                 '--append-users': False,
                 },
-            stdin=BytesIO(b'{"id": "used", "title": "here"}\n'),
+            stdin=BytesIO(b'{"id": "used", "title": "here", "users": [{"capacity": "editor", "name": "test-user-new"}]}\n'),
             stdout=self.stdout)
         response = self.stdout.getvalue()
         self.assertEqual(response[-1:], b'\n')
@@ -756,6 +774,7 @@ class TestCLILoad(unittest.TestCase):
                 '--insecure': False,
                 '--resource-views': False,
                 '--datastore-fields': False,
+                '--include-users': True,
                 '--append-users': False,
                 },
             stdin=BytesIO(b'{"id": "unused", "users": []}\n'),
@@ -775,6 +794,7 @@ class TestCLILoad(unittest.TestCase):
                 '--insecure': False,
                 '--resource-views': False,
                 '--datastore-fields': False,
+                '--include-users': True,
                 '--append-users': False,
                 },
             stdin=BytesIO(b'{"id": "mems", "name": "mems", "users": [{"capacity": "editor", "name": "test-user"}]}\n'),
@@ -796,6 +816,7 @@ class TestCLILoad(unittest.TestCase):
                 '--insecure': False,
                 '--resource-views': False,
                 '--datastore-fields': False,
+                '--include-users': False,
                 '--append-users': True,
                 },
             stdin=BytesIO(b'{"id": "mems", "name": "mems", "users": [{"capacity": "admin", "name": "test-user-admin"}]}\n'),
@@ -806,7 +827,7 @@ class TestCLILoad(unittest.TestCase):
         timstamp, action, error, data = json.loads(response.decode('UTF-8'))
         self.assertEqual(action, 'update')
         self.assertEqual(error, None)
-        self.assertEqual(data, {'id': 'mems', 'name': 'mems', "set_members": ["test-user-admin[admin]"]})
+        self.assertEqual(data, {'id': 'mems', 'name': 'mems', "added_members": ["test-user-admin[admin]"]})
 
     def test_parent_load_two(self):
         load_things(self.ckan, 'datasets', {
@@ -830,6 +851,7 @@ class TestCLILoad(unittest.TestCase):
                 '--api-tokens': False,
                 '--resource-views': False,
                 '--datastore-fields': False,
+                '--include-users': False,
                 '--append-users': False,
             },
             worker_pool=self._mock_worker_pool,
@@ -869,6 +891,7 @@ class TestCLILoad(unittest.TestCase):
                 '--api-tokens': False,
                 '--resource-views': False,
                 '--datastore-fields': False,
+                '--include-users': False,
                 '--append-users': False,
             },
             worker_pool=self._mock_worker_pool,
@@ -911,6 +934,7 @@ class TestCLILoad(unittest.TestCase):
                 '--api-tokens': False,
                 '--resource-views': False,
                 '--datastore-fields': False,
+                '--include-users': False,
                 '--append-users': False,
             },
             worker_pool=self._mock_worker_pool,


### PR DESCRIPTION
feat(dev): append group users;

- Added an option to not truncate users.

Allows to "append" users to groups/organizations without fully truncating the group with new users. Case use would be merging a group from 2 CKAN instances into one, well maintaining the members from both groups.

cc: @wardi 

will work on some tests for this.